### PR TITLE
Implemented PowerShell Tools for the PI System and built in Cmdlets for applicable checks

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB4.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB4.psm1
@@ -53,8 +53,8 @@ Get functions from machine library.
 	$listOfFunctions.Add("Get-PISysAudit_CheckSQLOLEAutomationProcs", 1)			
 	$listOfFunctions.Add("Get-PISysAudit_CheckSQLsa", 1)
 	$listOfFunctions.Add("Get-PISysAudit_CheckSQLRemoteAccess", 1)
-	$listOfFunctions.Add("Get-PISysAudit_CheckCrossDBOwnershipChaining", 1)			
-	$listOfFunctions.Add("Get-PISysAudit_CheckCLR", 1)
+	$listOfFunctions.Add("Get-PISysAudit_CheckSQLCrossDBOwnershipChaining", 1)			
+	$listOfFunctions.Add("Get-PISysAudit_CheckSQLCLR", 1)
 
 	# Return the list.
 	return $listOfFunctions		
@@ -514,7 +514,7 @@ END {}
 #***************************
 }
 
-function Get-PISysAudit_CheckCLR
+function Get-PISysAudit_CheckSQLCLR
 {
 <#  
 .SYNOPSIS
@@ -628,7 +628,7 @@ END {}
 #***************************
 }
 
-function Get-PISysAudit_CheckCrossDBOwnershipChaining
+function Get-PISysAudit_CheckSQLCrossDBOwnershipChaining
 {
 <#  
 .SYNOPSIS
@@ -1093,8 +1093,8 @@ Export-ModuleMember Get-PISysAudit_CheckSQLDBMailXPs
 Export-ModuleMember Get-PISysAudit_CheckSQLOLEAutomationProcs
 Export-ModuleMember Get-PISysAudit_CheckSQLsa
 Export-ModuleMember Get-PISysAudit_CheckSQLRemoteAccess
-Export-ModuleMember Get-PISysAudit_CheckCrossDBOwnershipChaining
-Export-ModuleMember Get-PISysAudit_CheckCLR
+Export-ModuleMember Get-PISysAudit_CheckSQLCrossDBOwnershipChaining
+Export-ModuleMember Get-PISysAudit_CheckSQLCLR
 # </Do not remove>
 
 # ........................................................................

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB4.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB4.psm1
@@ -108,13 +108,22 @@ PROCESS
 	$msg = ""
 	try
 	{											
-		# Build and execute the query.			
-		$query = "SELECT value_in_use FROM Master.sys.configurations WHERE name = 'xp_cmdshell'"		
-		$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
-																		-q $query -rspc $true -InstanceName $InstanceName `
-																		-IntegratedSecurity $IntegratedSecurity `
-																		-user $UserName -pf $PasswordFile `
-																		-dbgl $DBGLevel	
+		# Build and execute the query.
+		$requestedScalar = "value_in_use"			
+		$queryTemplate = "SELECT {0} FROM Master.sys.configurations WHERE name = 'xp_cmdshell'"
+		$query = [string]::Format($queryTemplate,$requestedScalar)
+		if($PSVersionTable.PSVersion.Major -gt 2 -and $PasswordFile -eq "")
+		{
+			$value = Invoke-Sqlcmd_ScalarValue -Query $query -RemoteComputerName $RemoteComputerName -InstanceName $InstanceName -ScalarValue $requestedScalar	
+		}	
+		else
+		{
+			$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
+																			-q $query -rspc $true -InstanceName $InstanceName `
+																			-IntegratedSecurity $IntegratedSecurity `
+																			-user $UserName -pf $PasswordFile `
+																			-dbgl $DBGLevel	
+		}
 								
 		# Check if the value is 1 = not compliant, 0 it is.								
 		if($null -eq $value)
@@ -212,13 +221,22 @@ PROCESS
 	$msg = ""
 	try
 	{											
-		# Build and execute the query.			
-		$query = "SELECT value_in_use FROM Master.sys.configurations WHERE name = 'Ad Hoc Distributed Queries'"				
-		$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
-																		-q $query -rspc $true -InstanceName $InstanceName `
-																		-IntegratedSecurity $IntegratedSecurity `
-																		-user $UserName -pf $PasswordFile `
-																		-dbgl $DBGLevel	
+		# Build and execute the query.
+		$requestedScalar = "value_in_use"			
+		$queryTemplate = "SELECT {0} FROM Master.sys.configurations WHERE name = 'Ad Hoc Distributed Queries'"
+		$query = [string]::Format($queryTemplate,$requestedScalar)
+		if($PSVersionTable.PSVersion.Major -gt 2 -and $PasswordFile -eq "")
+		{
+			$value = Invoke-Sqlcmd_ScalarValue -Query $query -RemoteComputerName $RemoteComputerName -InstanceName $InstanceName -ScalarValue $requestedScalar	
+		}	
+		else
+		{			
+			$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
+																			-q $query -rspc $true -InstanceName $InstanceName `
+																			-IntegratedSecurity $IntegratedSecurity `
+																			-user $UserName -pf $PasswordFile `
+																			-dbgl $DBGLevel	
+		}
 		
 		# Check if the value is 1 = not compliant, 0 it is.								
 		if($null -eq $value)
@@ -316,13 +334,23 @@ PROCESS
 	$msg = ""
 	try
 	{											
-		# Build and execute the query.			
-		$query = "SELECT value_in_use FROM Master.sys.configurations WHERE name = 'Database Mail XPs'"				
-		$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
-																		-q $query -rspc $true -InstanceName $InstanceName `
-																		-IntegratedSecurity $IntegratedSecurity `
-																		-user $UserName -pf $PasswordFile `
-																		-dbgl $DBGLevel	
+		
+		# Build and execute the query.
+		$requestedScalar = "value_in_use"			
+		$queryTemplate = "SELECT {0} FROM Master.sys.configurations WHERE name = 'Database Mail XPs'"
+		$query = [string]::Format($queryTemplate,$requestedScalar)
+		if($PSVersionTable.PSVersion.Major -gt 2 -and $PasswordFile -eq "")
+		{
+			$value = Invoke-Sqlcmd_ScalarValue -Query $query -RemoteComputerName $RemoteComputerName -InstanceName $InstanceName -ScalarValue $requestedScalar	
+		}	
+		else
+		{			
+			$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
+																			-q $query -rspc $true -InstanceName $InstanceName `
+																			-IntegratedSecurity $IntegratedSecurity `
+																			-user $UserName -pf $PasswordFile `
+																			-dbgl $DBGLevel	
+		}
 		
 		# Check if the value is 1 = not compliant, 0 it is.								
 		if($null -eq $value)
@@ -420,13 +448,23 @@ PROCESS
 	$msg = ""
 	try
 	{											
-		# Build and execute the query.			
-		$query = "SELECT value_in_use FROM Master.sys.configurations WHERE name = 'Ole Automation Procedures'"				
-		$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
-																		-q $query -rspc $true -InstanceName $InstanceName `
-																		-IntegratedSecurity $IntegratedSecurity `
-																		-user $UserName -pf $PasswordFile `
-																		-dbgl $DBGLevel	
+		
+		# Build and execute the query.
+		$requestedScalar = "value_in_use"			
+		$queryTemplate = "SELECT {0} FROM Master.sys.configurations WHERE name = 'Ole Automation Procedures'"
+		$query = [string]::Format($queryTemplate,$requestedScalar)
+		if($PSVersionTable.PSVersion.Major -gt 2 -and $PasswordFile -eq "")
+		{
+			$value = Invoke-Sqlcmd_ScalarValue -Query $query -RemoteComputerName $RemoteComputerName -InstanceName $InstanceName -ScalarValue $requestedScalar	
+		}	
+		else
+		{			
+			$value = Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery -lc $LocalComputer -rcn $RemoteComputerName `
+																			-q $query -rspc $true -InstanceName $InstanceName `
+																			-IntegratedSecurity $IntegratedSecurity `
+																			-user $UserName -pf $PasswordFile `
+																			-dbgl $DBGLevel	
+		}	
 		
 		# Check if the value is 1 = not compliant, 0 it is.								
 		if($null -eq $value)

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1574,7 +1574,8 @@ param(
 		$ShowUI = (Get-Variable "PISysAuditShowUI" -Scope "Global" -ErrorAction "SilentlyContinue").Value					
 				
 		# Validate the presence of a SQL Server
-		if($PSVersionTable.PSVersion.Major -gt 2 -and $ComputerParams.PasswordFile -eq "")
+		$global:UseSQLCmdlets = $PSVersionTable.PSVersion.Major -gt 2 -and $ComputerParams.PasswordFile -eq ""
+		if($global:UseSQLCmdlets)
 		{
 			try
 			{

--- a/PISecurityAudit/en-US/about_PISYSAUDIT.help.txt
+++ b/PISecurityAudit/en-US/about_PISYSAUDIT.help.txt
@@ -132,7 +132,7 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		removing PIWorld access, you need to evaluate which applications are relying on that 
 		access so that you can grant those applications access explicitly.
 
-		AU20002 - PI Admin Trusts Disabled Check
+		AU20002 - PI Admin Usage Check
 		VALIDATION: verifies that the piadmin PI User is not used in mappings or trusts.
 		COMPLIANCE: replace any trusts or mappings that use piadmin with a mapping or trust to a
 		PI Identity with appropriate privilege for the applications that will use it.  Will also
@@ -268,6 +268,37 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		more information, see:
 		https://msdn.microsoft.com/en-us/library/ms191188.aspx
 
+		AU40005 - SQL Server CLR Configuration Option Check
+		VALIDATION: verifies that SQL Server does not have CLR enabled. 
+		COMPLIANCE: disable the CLR option.  This option can be configured using 
+		the Policy-Based Management or the sp_configure stored procedure. For 
+		more information, see:
+		https://msdn.microsoft.com/en-us/library/ms191188.aspx
+
+		AU40006 - SQL Server Cross DB Ownership Chaining Option Check
+		VALIDATION: verifies that SQL Server does not have Cross DB Ownership 
+		Chaining enabled. 
+		COMPLIANCE: disable the Cross DB Ownership Chaining option.  This option 
+		can be configured using the Policy-Based Management or the sp_configure 
+		stored procedure. For more information, see:
+		https://msdn.microsoft.com/en-us/library/ms191188.aspx
+
+		AU40007 - SQL Server Remote Access Option Check
+		VALIDATION: verifies that SQL Server does not have Remote Access 
+		enabled. 
+		COMPLIANCE: disable the Remote Access option.  This option can 
+		be configured using the Policy-Based Management or the sp_configure 
+		stored procedure. For more information, see:
+		https://msdn.microsoft.com/en-us/library/ms191188.aspx
+
+		AU40008 - SQL Server sa Login Check
+		VALIDATION: verifies that SQL Server does not have the sa login enabled 
+		enabled. 
+		COMPLIANCE: disable the sa login.  This option can 
+		be configured using the Policy-Based Management or the sp_configure 
+		stored procedure. For more information, see:
+		https://msdn.microsoft.com/en-us/library/ms191188.aspx
+
 		AU50001 - Check for latest version of Coresight
 		VALIDATION: verifies PI Coresight version.
 		COMPLIANCE: upgrade to the latest version of PI Coresight.  For more information, 
@@ -312,6 +343,7 @@ CONTRIBUTE
         https://github.com/osisoft/PI-System-Audit-Tools/issues
         
         
+
 
 
 


### PR DESCRIPTION
I implemented a global check to determine the availability of the PowerShell Tools for the PI System.  Based on the availability of the tools, the PowerShell tools will be used rather than the piconfig invocation.  In order to support this, I added the PowerShell tool calls and fallback to piconfig for all data archive validations.

This is intended to address Issue #79.