### PR TITLE
Fixes for issues with default install settings

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -81,9 +81,15 @@ function SetFolders
 	New-Variable -Name "ScriptsPath" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $scriptsPath
 	New-Variable -Name "ScriptsPathTemp" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $scriptsPathTemp			
 	New-Variable -Name "PasswordPath" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $pwdPath
-	New-Variable -Name "ExportPath" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $exportPath
+	if($null -eq (Get-Variable "ExportPath" -Scope "Global" -ErrorAction "SilentlyContinue").Value)
+	{
+		New-Variable -Name "ExportPath" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $exportPath
+	}
 	New-Variable -Name "PIConfigScriptPath" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $picnfgPath
-	New-Variable -Name "PISystemAuditLogFile" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $logFile	
+	if($null -eq (Get-Variable "PISystemAuditLogFile" -Scope "Global" -ErrorAction "SilentlyContinue").Value)
+	{
+		New-Variable -Name "PISystemAuditLogFile" -Option "Constant" -Scope "Global" -Visibility "Public" -Value $logFile	
+	}
 }
 
 function NewObfuscateValue

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -2357,6 +2357,85 @@ END {}
 #***************************
 }
 
+function Test-PISysAudit_IISModuleAvailable
+{
+<#
+.SYNOPSIS
+(Core functionality) Enables use of the WebAdministration module.
+.DESCRIPTION
+Validate that IIS module can be loaded and configuration data can be accessed.
+#>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
+param(
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lc")]
+		[boolean]
+		$LocalComputer = $true,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("rcn")]
+		[string]
+		$RemoteComputerName = "",
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("dbgl")]
+		[int]
+		$DBGLevel = 0)		
+BEGIN {}
+PROCESS
+{			
+	$fn = GetFunctionName
+	$value = $false
+	try
+	{
+		$query = 'Test-Path IIS:\'
+		$scriptBlock = [scriptblock]::create( $query )
+		# Execute the Get-ItemProperty cmdlet method locally or remotely via the Invoke-Command cmdlet
+		if($LocalComputer)		
+		{						
+			
+			# Import the WebAdministration module
+			Import-Module -Name "WebAdministration"		
+			
+			# Execute the command locally	
+			$value = Invoke-Command -ScriptBlock $scriptBlock			
+		}
+		else
+		{	
+					
+			# Establishing a new PS session on a remote computer		
+			$PSSession = New-PSSession -ComputerName $RemoteComputerName
+
+			# Importing WebAdministration module within the PS session
+			Invoke-Command -Session $PSSession -ScriptBlock {Import-Module WebAdministration}
+			
+			# Execute the command within a remote PS session
+			$value = Invoke-Command -Session $PSSession -ScriptBlock $scriptBlock
+			Remove-PSSession -ComputerName $RemoteComputerName
+		}
+	
+		# Return the value found.
+		return $value		
+	}
+	catch
+	{
+		# Return the error message.
+		$msgTemplate1 = "A problem occurred checking for IIS scripting tools: {0} from local machine."
+		$msgTemplate2 = "A problem occurred checking for IIS scripting tools: {0} from {1} machine."
+		if($LocalComputer)
+		{ $msg = [string]::Format($msgTemplate1, $_.Exception.Message) }
+		else
+		{ $msg = [string]::Format($msgTemplate2, $_.Exception.Message) }
+		Write-PISysAudit_LogMessage $msg "Error" $fn -eo $_				
+		return $null
+	}
+}
+
+END {}
+
+#***************************
+#End of exported function
+#***************************
+}
+
 function Get-PISysAudit_IISproperties
 {
 <#
@@ -5156,6 +5235,7 @@ Export-ModuleMember Invoke-PISysAudit_ADONET_ScalarValueFromSQLServerQuery
 Export-ModuleMember Invoke-PISysAudit_SQLCMD_ScalarValueFromSQLServerQuery
 Export-ModuleMember Invoke-Sqlcmd_ScalarValue
 Export-ModuleMember Invoke-PISysAudit_SPN
+Export-ModuleMember Test-PISysAudit_IISModuleAvailable
 Export-ModuleMember Get-PISysAudit_IISproperties
 Export-ModuleMember New-PISysAuditObject
 Export-ModuleMember New-PISysAudit_PasswordOnDisk


### PR DESCRIPTION
Issue1: Script continued execution even if the IIS:\ drive could not be navigated.  Sometimes the WebAdministration module is imported without error, but the paths are not actually accessible.  
Fix1: Added a core check to verify that the IIS drive is accessible
Issue2: app pool user was returning null if set to a Built in account
Fix2: Type and user are equal if type is a built in option
Issue3: AuthProviders always checked locally
Fix3: used IISProperties call from core library.

Enhancement: Added multiple domain support when checking web server SPNs.  Minimal work was required since the call for account domain was already in place.