### PR TITLE
Increased support for multiple domains and fixed a few issues with machine accounts

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
@@ -599,7 +599,7 @@ PROCESS
 		# Coresight is running under a machine account.
 		Else 
 		{ 
-			$csappPool = $hostname 
+			$csappPool = $global:CSAppPoolSvc
 
 			# Machine accounts don't need HTTP service class - it's already included in the HOST service class.
 			$serviceType = "host"

--- a/PISecurityAudit/Scripts/Utilities/CoresightKerberosConfiguration.psm1
+++ b/PISecurityAudit/Scripts/Utilities/CoresightKerberosConfiguration.psm1
@@ -729,7 +729,7 @@ If ($ADMtemp) {
 	If($ComputerName -eq ""){$LocalComputer = $true}
 	Else{$LocalComputer = $false}
 
-	if(Test-PISysAudit_IISModuleAvailable -lc $LocalComputer -rcn $RemoteComputerName -dbgl $DBGLevel)
+	if(Test-WebAdministrationModuleAvailable -lc $LocalComputer -rcn $RemoteComputerName -dbgl $DBGLevel)
 	{
 		$msg = 'WebAdministration module loaded successfully.'
 		Write-PISysAudit_LogMessage $msg "debug" $fn -dbgl $DBGLevel -rdbgl 2


### PR DESCRIPTION
1. Main focus of these commits was support across trusted domains.  Changes setspn implementation to use
setspn -l Domain\User
Issues were encountered with the setspn -q approach when the account display name did not match the user logon.  Circumventing that issue would require additional calls to AD, so to prevent further complications, I opted for -l since it provides cross domain access calls. 

2. Network Service and other machine accounts were having issues in my test environments, so I separated the parsing of the username from the raw string into a separate function to handle all of the cases without complicating the logic in the Kerberos check.  

Three general housekeeping items:
1. moved Get-KnownServers to core since other checks and utilities may need this information.
2. Made WebAdministration availability check more consistent with OSIsoft.PowerShell check.
3. Filtered out issues section when the issue count is 0