### PR TITLE
Improved feedback to user if initialization fails.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1972,7 +1972,8 @@ PROCESS
 		cls
 		
 		# Set the ShowUI flag
-		New-Variable -Name "PISysAuditShowUI" -Scope "Global" -Visibility "Public" -Value $ShowUI		
+		if($null -eq (Get-Variable "PISysAuditShowUI" -Scope "Global" -ErrorAction "SilentlyContinue").Value)
+		{ New-Variable -Name "PISysAuditShowUI" -Scope "Global" -Visibility "Public" -Value $true }		
 									
 		# Set an PISysAuditInitialized flag
 		New-Variable -Name "PISysAuditInitialized" -Scope "Global" -Visibility "Public" -Value $true				


### PR DESCRIPTION
Initialization errors due to WSMan issues and WebAdministration unavailable were not surfacing for test users.  Made a couple changes to correct this:

-Defined ShowUI Global in initialization function
-Moved Web Administration test and global initializations to the Initialize function for clarity since they are not part of the kerberos logic.
-Improved wording/format of the messages.