### PR TITLE
Removed SQL Server and PI Coresight role from audit

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3354,7 +3354,7 @@ PROCESS
 		else
 		{																		
 			$PIHome_path = Get-PISysAudit_EnvVariable "PIHOME" -lc $false -rcn $RemoteComputerName
-			# Set the PIPC\log folder (64 bit).
+			# Set the PIPC\dat folder (64 bit).
 			$scriptTempFilesPath = PathConcat -ParentPath $PIHome_path -ChildPath "dat"		                                       						                                   					                                      
 			# Define the arguments required by the afdiag.exe command						
 			$argListTemplate = "'/ExeFile:`"{0}`"'"	
@@ -5284,11 +5284,10 @@ PROCESS
 		# Initialize.
 		$ComputerParamsTable = @{}
 		
-		# This means an audit on the local computer is required
+		# This means an audit on the local computer is required only PI Data Archive and PI AF Server are checked by default.
+		# SQL Server checks ommitted by default as SQL Server will often require an instancename
 		$ComputerParamsTable = New-PISysAuditComputerParams $ComputerParamsTable "localhost" "PIServer"
-		$ComputerParamsTable = New-PISysAuditComputerParams $ComputerParamsTable "localhost" "PIAFServer"
-		$ComputerParamsTable = New-PISysAuditComputerParams $ComputerParamsTable "localhost" "SQLServer"
-		$ComputerParamsTable = New-PISysAuditComputerParams $ComputerParamsTable "localhost" "PICoresightServer"		
+		$ComputerParamsTable = New-PISysAuditComputerParams $ComputerParamsTable "localhost" "PIAFServer"	
 	}
 	
 	# ............................................................................................................


### PR DESCRIPTION
Removed SQL Server and PI Coresight from audit when no parameters are specified.  These checks often fail with the default audit because the machine does not have PI Coresight installed and the SQL Server audit usually requires more information such as instancename.