### PR TITLE
Added Error Table to HTML Report

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1378,31 +1378,31 @@ param(
 				}
 				else
 				{
-					$msgTemplate = "Unable to access the PI Data Archive {0} with PowerShell.  Check if there is a valid mapping for your user."
+					$msgTemplate = "Unable to access the PI Data Archive {0} with PowerShell.  Check if there is a valid mapping for your user. Terminating PI Data Archive audit"
 					$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
-					Write-PISysAudit_LogMessage $msg "Warning" $fn
+					Write-PISysAudit_LogMessage $msg "Error" $fn
+					$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI Data Archive Audit" -fn $fn -msg $msg
 					return
 				}
 			}
 			catch
 			{
 				# Return the error message.
-				$msgTemplate = "An error occurred connecting to the PI Data Archive {0} with PowerShell."
+				$msgTemplate = "An error occurred connecting to the PI Data Archive {0} with PowerShell. Terminating PI Data Archive audit"
 				$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 				Write-PISysAudit_LogMessage $msg "Error" $fn -eo $_
+				$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI Data Archive Audit" -fn $fn -msg $msg
 				return
 			}
 		}
 		else
 		{
-			$msg = "Unable to locate the PowerShell Tools for the PI System on the computer running this script. Terminating PI Data Archive audit"
+			$msg = "Unable to locate module OSIsoft.Powershell on the computer running this script. Terminating PI Data Archive audit"
 			Write-PISysAudit_LogMessage $msg "Error" $fn
-			$AuditTable = New-PISysAuditObject -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-										-at $AuditTable -id "Error" `
-										-ain "PI Data Archive Audit" -aiv "Error" `
-										-aif $fn -msg $msg `
-										-Group1 "PI System" -Group2 "PI Data Archive" `
-										-Severity "N/A"
+			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI Data Archive Audit" -fn $fn -msg $msg
 			return
 		}
 		
@@ -1529,6 +1529,8 @@ param(
 			$msgTemplate = "The computer {0} does not have a PI AF Server role or the validation failed"
 			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
+			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI AF Server Audit" -fn $fn -msg $msg
 			return
 		}
 		
@@ -1568,9 +1570,11 @@ param(
 			catch
 			{
 				# Return the error message.
-				$msgTemplate = "An error occurred connecting to the PI Data Archive {0} with PowerShell."
+				$msgTemplate = "An error occurred connecting to the PI AF Server {0} with PowerShell."
 				$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 				Write-PISysAudit_LogMessage $msg "Error" $fn -eo $_
+				$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI AF Server Audit" -fn $fn -msg $msg
 				return
 			}
 		}
@@ -1663,20 +1667,18 @@ param(
 					$msgTemplate = "The computer {0} does not have a SQL Server role or the validation failed"
 					$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 					Write-PISysAudit_LogMessage $msg "Warning" $fn
+					$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "SQL Server Audit" -fn $fn -msg $msg
 					return
 				}
 				
 				if (-not (Get-Module -ListAvailable -Name SQLPS))
 				{
 					# Return if SQLPS not available on machine
-					$msg = "Module 'SQLPS' is required to execute the SQL Server audit checks"
+					$msg = "Unable to locate module SQLPS on the computer running this script. Terminating SQL Server audit"
 					Write-PISysAudit_LogMessage $msg "Error" $fn
-					$AuditTable = New-PISysAuditObject -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-										-at $AuditTable -id "Error" `
-										-ain "SQL Server Audit" -aiv "Error" `
-										-aif $fn -msg $msg `
-										-Group1 "Machine" -Group2 "SQL Server" `
-										-Severity "N/A"
+					$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "SQL Server Audit" -fn $fn -msg $msg
 					return
 				}
 
@@ -1696,6 +1698,8 @@ param(
 				$msgTemplate = "Could not execute test query against SQL Server on computer {0}"
 				$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 				Write-PISysAudit_LogMessage $msg "Warning" $fn
+				$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+						-at $AuditTable -an "SQL Server Audit" -fn $fn -msg $msg
 				return
 			}
 
@@ -1802,6 +1806,8 @@ param(
 			$msgTemplate = "The computer {0} does not have the PI Coresight role or the validation failed"
 			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
+			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
 			return
 		}
 
@@ -1809,6 +1815,8 @@ param(
 		{
 			$msg = "Elevation required to run Audit checks using IIS Cmdlet.  Run PowerShell as Administrator to complete these checks."
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
+			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
 			return
 		}
 
@@ -1818,6 +1826,8 @@ param(
 			$msgTemplate = "The computer {0} does not have the IIS Management Scripting Tools Feature (IIS cmdlets) or the validation failed; some audit checks may not be available."
 			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
+			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
 			return
 		}
 		
@@ -3964,6 +3974,80 @@ END {}
 #***************************
 }
 
+function New-PISysAuditError
+{
+<#
+.SYNOPSIS
+(Core functionality) Create an audit error object and place it inside a hash table object.
+.DESCRIPTION
+Create an audit error object and place it inside a hash table object.
+#>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
+param(
+		[parameter(Mandatory=$true, ParameterSetName = "Default")]
+		[AllowEmptyString()]
+		[alias("lc")]
+		[boolean]
+		$LocalComputer,
+		[parameter(Mandatory=$true, ParameterSetName = "Default")]
+		[AllowEmptyString()]
+		[alias("rcn")]
+		[string]
+		$RemoteComputerName,
+		[parameter(Mandatory=$true, ParameterSetName = "Default")]
+		[alias("at")]
+		[System.Collections.HashTable]
+		$AuditHashTable,
+		[parameter(Mandatory=$true, ParameterSetName = "Default")]
+		[alias("an")]
+		[String]
+		$AuditName,
+		[parameter(Mandatory=$true, ParameterSetName = "Default")]
+		[alias("fn")]
+		[String]
+		$FunctionName,
+		[parameter(Mandatory=$true, ParameterSetName = "Default")]
+		[alias("msg")]
+		[String]
+		$MessageList = "")
+
+BEGIN {}
+PROCESS		
+{
+	$fn = GetFunctionName
+
+	# Define the server name to use for reporting.
+	$computerName = ResolveComputerName $LocalComputer $RemoteComputerName
+
+	# Create a custom object.
+	$tempObj = New-Object PSCustomObject
+	
+	# Create an unique ID with format "ERROR_<function>-<computerName>
+	$myKey = "ERROR_" + $FunctionName + "-" + $computerName
+	
+	# If the validation succeeds, there is no issue; if the validation fails, we can't accurately assess severity.
+
+	# Set the properties.
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "Severity" -Value "Error"
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ServerName" -Value $computerName
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditName" -Value $AuditName
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "FunctionName" -Value $FunctionName
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "MessageList" -Value $MessageList
+	
+	# Add this custom object to the hash table.
+	$AuditHashTable.Add($myKey, $tempObj)
+	
+	# return the table
+	return $AuditHashTable
+}
+
+END {}
+
+#***************************
+#End of exported function
+#***************************
+}
+
 function New-PISysAuditComputerParams
 {
 <#
@@ -4286,9 +4370,16 @@ PROCESS
 		$fileName = "PISecurityAudit_$reportFileTimestamp.csv"
 		$fileToExport = PathConcat -ParentPath $exportPath -ChildPath $fileName
 
+		# Build a collection for errors
+		$errs = @()
+		foreach($item in $AuditHashTable.GetEnumerator() | Where-Object Name -Like "ERROR*")
+		{
+			$errs += $item.Value
+		}
+
 		# Build a collection for output.
-		$results = @()	
-		foreach($item in $AuditHashTable.GetEnumerator())			
+		$results = @()
+		foreach($item in $AuditHashTable.GetEnumerator() | Where-Object Name -NotLike "ERROR*")
 		{
 			# Protect sensitive data if necessary.
 			if($ObfuscateSensitiveData)
@@ -4309,9 +4400,7 @@ PROCESS
 		}
 		
 		# Export to .csv but sort the results table first to have Failed items on the top sorted by Severity 
-		$errs = $results | Where-Object AuditItemValue -EQ 'Error'
-		$results = $results | Where-Object AuditItemValue -NE 'Error' | Sort-Object @{Expression="AuditItemValue";Descending=$false},@{Expression="Severity";Descending=$true},@{Expression="ID";Descending=$false}
-		$results = $results + $errs
+		$results = $results | Sort-Object @{Expression="AuditItemValue";Descending=$false},@{Expression="Severity";Descending=$true},@{Expression="ID";Descending=$false}
 		$results | Export-Csv -Path $fileToExport -Encoding ASCII -NoType
 	
 		
@@ -4321,6 +4410,42 @@ PROCESS
 
 			$fileToExport = PathConcat -ParentPath $exportPath -ChildPath $fileName
 
+			# Construct HTML table for errors
+			$errorRows = ""
+			if($errs){ 
+				foreach($err in $errs)
+				{
+					$style = "`"error`""
+					$errorRow = @"
+					<tr class=$style>
+						<td>$($err.Severity)</td>
+						<td>$($err.ServerName)</td>
+						<td>$($err.AuditName)</td>
+						<td>$($err.MessageList)</td>
+					</tr>
+"@
+					$errorRows += $errorRow
+				}
+				$errorTable = @"
+					<table class="errortable table">
+						<thead>
+							<tr>
+								<th colspan="4">Errors</th>
+							</tr>
+						</thead>
+						<thead>
+							<tr>
+								<th>Severity</th>
+								<th>Server</th>
+								<th>Audit Name</th>
+								<th>Message</th>
+							</tr>
+						</thead>
+						$errorRows
+					</table>
+					<br/>
+"@
+			}
 
 			# Construct HTML table and color code the rows by result and severity.
 			$tableRows=""
@@ -4329,11 +4454,11 @@ PROCESS
 				$highlight = "`"`""
 				switch ($result.Severity.ToLower())
 				{
-					"severe" {$highlight="`"error`""; break}
-					"moderate" {$highlight="`"warning`""; break}
-					"low" {$highlight="`"info`""; break}
+					"severe" {$highlight="`"severe`""; break}
+					"moderate" {$highlight="`"moderate`""; break}
+					"low" {$highlight="`"low`""; break}
 				}
-				if ($result.AuditItemValue -eq 'Error') { $highlight="`"redtext`"" }
+				if ($result.AuditItemValue -eq "N/A") {$highlight="`"error`""}
 	
 				$anchorTag=""
 				if($result.AuditItemValue -ieq "fail"){
@@ -4415,18 +4540,31 @@ PROCESS
 							background-color: #f2f2f2;
 						}
 
+						.errortable {
+							width: 100%;
+							border-collapse: collapse;
+							}
+
+						.errortable td, .errortable th {
+							border: 1px solid #ddd;
+							font-size: 0.875em;
+						}
+						.errortable th{
+							background-color: #f2f2f2;
+						}
+
 			
-						.info{
+						.low{
 							background-color: #FFF59D;
 						}
 			
-						.warning{
+						.moderate{
 							background-color: #FFCC80;
 						}
-						.error{
+						.severe{
 							background-color: #FFAB91;
 						}
-						.redtext{
+						.error{
 							color: #FF0000;
 						}
 					</style>
@@ -4439,7 +4577,14 @@ PROCESS
 						<h4>$reportTimestamp</h4> 
 					</div>
 
+					$errorTable
+
 					<table class="summarytable table">
+						<thead>
+							<tr>
+								<th colspan="8">Audit Results</th>
+							</tr>
+						</thead>
 						<thead>	
 							<tr>
 								<th>ID</th>
@@ -4755,6 +4900,7 @@ Export-ModuleMember Invoke-PISysAudit_Sqlcmd_ScalarValue
 Export-ModuleMember Invoke-PISysAudit_SPN
 Export-ModuleMember Get-PISysAudit_IISproperties
 Export-ModuleMember New-PISysAuditObject
+Export-ModuleMember New-PISysAuditError
 Export-ModuleMember New-PISysAudit_PasswordOnDisk
 Export-ModuleMember New-PISysAuditComputerParams
 Export-ModuleMember New-PISysAuditReport

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1660,6 +1660,14 @@ param(
 					return
 				}
 				
+				if (-not (Get-Module -ListAvailable -Name SQLPS))
+				{
+					# Return if SQLPS not available on machine
+					$msg = "Module 'SQLPS' is required to execute the SQL Server audit checks"
+					Write-PISysAudit_LogMessage $msg "Error" $fn
+					return
+				}
+
 				# Push and Pop are to prevent a context switch to the SQL shell from persisting after invocation of SQL commands.
 				Push-Location
 				Import-Module SQLPS -DisableNameChecking


### PR DESCRIPTION
This handles #116  

-Added core cmdlet New-PISysAuditError
	> This stores errors in same AuditHashTable as audit check results, prefixed with "ERROR_"
-Changed Write-PISysAuditReport to extract these error objects and build an Error table above the audit check results table.
-Changed Audit item results table to highlight "N/A" results in red as errors
-SQL Server audit will quit before running any checks if SQLPS is not present