### PR TITLE
Added support for multiple levels of audit checks

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
@@ -51,8 +51,15 @@ function Get-PISysAudit_FunctionsFromLibrary1
 {
 <#  
 .SYNOPSIS
-Get functions from machine library.
+Get functions from machine library at or below the specified level.
 #>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
+param(
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1)
+
 	# Form a list of all functions that need to be called to test
 	# the machine compliance.
 	$listOfFunctions = @()
@@ -64,8 +71,8 @@ Get functions from machine library.
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckManagedPI"          1    # AU10006
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckIEEnhancedSecurity" 1    # AU10007
 			
-	# Return the list.
-	return $listOfFunctions
+	# Return all items at or below the specified AuditLevelInt
+	return $listOfFunctions | Where-Object Level -LE $AuditLevelInt
 }
 
 function Get-PISysAudit_CheckDomainMemberShip

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
@@ -51,8 +51,15 @@ function Get-PISysAudit_FunctionsFromLibrary2
 {
 <#  
 .SYNOPSIS
-Get functions from PI Data Archive library.
+Get functions from PI Data Archive library at or below the specified level.
 #>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
+param(
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1)
+
 	# Form a list of all functions that need to be called to test
 	# the PI Data Archive compliance.
 	$listOfFunctions = @()
@@ -68,8 +75,8 @@ Get functions from PI Data Archive library.
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckInstalledClientSoftware"              1 # AU20010
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckPIFirewall"                           1 # AU20011
 				
-	# Return the list.
-	return $listOfFunctions	
+	# Return all items at or below the specified AuditLevelInt
+	return $listOfFunctions | Where-Object Level -LE $AuditLevelInt
 }
 
 function Get-PISysAudit_CheckPIServerDBSecurity_PIWorldReadAccess

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -51,8 +51,15 @@ function Get-PISysAudit_FunctionsFromLibrary3
 {
 <#  
 .SYNOPSIS
-Get functions from PI AF Server library.
+Get functions from PI AF Server library at or below the specified level.
 #>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
+param(
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1)
+
 	# Form a list of all functions that need to be called to test
 	# the PI AF Server compliance.
 	$listOfFunctions = @()
@@ -66,8 +73,8 @@ Get functions from PI AF Server library.
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckAFServerAdminRight"              1 # AU30008
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckAFConnectionString"              1 # AU30009
 
-	# Return the list.
-	return $listOfFunctions
+	# Return all items at or below the specified AuditLevelInt
+	return $listOfFunctions | Where-Object Level -LE $AuditLevelInt
 }
 
 function Get-PISysAudit_CheckPIAFServiceConfiguredAccount

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB4.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB4.psm1
@@ -51,8 +51,15 @@ function Get-PISysAudit_FunctionsFromLibrary4
 {
 <#  
 .SYNOPSIS
-Get functions from machine library.
+Get functions from SQL Server library at or below the specified level.
 #>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
+param(
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1)
+
 	# Form a list of all functions that need to be called to test
 	# the SQL Server compliance.
 	$listOfFunctions = @()
@@ -65,8 +72,8 @@ Get functions from machine library.
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckSQLCrossDBOwnershipChaining" 1 # AU40007
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckSQLCLR"                      1 # AU40008
 
-	# Return the list.
-	return $listOfFunctions		
+	# Return all items at or below the specified AuditLevelInt
+	return $listOfFunctions | Where-Object Level -LE $AuditLevelInt	
 }
 
 function Get-PISysAudit_CheckSQLXPCommandShell

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
@@ -50,8 +50,15 @@ function Get-PISysAudit_FunctionsFromLibrary5
 {
 <#  
 .SYNOPSIS
-Get functions from machine library.
+Get functions from Coresight library at or below the specified level.
 #>
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
+param(
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1)
+
 	# Form a list of all functions that need to be called to test
 	# the machine compliance.
 	$listOfFunctions = @()
@@ -60,8 +67,8 @@ Get functions from machine library.
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CoresightSSLcheck"      1 # AU50003
 	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CoresightSPNcheck"      1 # AU50004
 	
-	# Return the list.
-	return $listOfFunctions
+	# Return all items at or below the specified AuditLevelInt
+	return $listOfFunctions | Where-Object Level -LE $AuditLevelInt
 }
 
 function Get-PISysAudit_CheckCoresightVersion

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1234,6 +1234,10 @@ param(
 		[alias("cp")]
 		$ComputerParams,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dbgl")]
 		[int]
 		$DBGLevel = 0)	
@@ -1247,7 +1251,7 @@ param(
 		$ShowUI = (Get-Variable "PISysAuditShowUI" -Scope "Global" -ErrorAction "SilentlyContinue").Value					
 		
 		# Get the list of functions to execute.
-		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary1				
+		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary1 -lvl $AuditLevelInt
 		# There is nothing to execute.
 		if($listOfFunctions.Count -eq 0)		
 		{
@@ -1319,6 +1323,10 @@ param(
 		[parameter(Mandatory=$true, Position=1, ParameterSetName = "Default")]
 		[alias("cp")]		
 		$ComputerParams,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dbgl")]
 		[int]
@@ -1402,7 +1410,7 @@ param(
 		}
 		
 		# Get the list of functions to execute.
-		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary2
+		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary2 -lvl $AuditLevelInt
 		# There is nothing to execute.
 		if($listOfFunctions.Count -eq 0)		
 		{
@@ -1505,6 +1513,10 @@ param(
 		[alias("cp")]		
 		$ComputerParams,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dbgl")]
 		[int]
 		$DBGLevel = 0)	
@@ -1531,7 +1543,7 @@ param(
 		}
 		
 		# Get the list of functions to execute.
-		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary3
+		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary3 -lvl $AuditLevelInt
 		# There is nothing to execute.
 		if($listOfFunctions.Count -eq 0)		
 		{
@@ -1640,7 +1652,11 @@ param(
 		$AuditTable,		
 		[parameter(Mandatory=$true, Position=1, ParameterSetName = "Default")]
 		[alias("cp")]		
-		$ComputerParams,				
+		$ComputerParams,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dbgl")]
 		[int]
@@ -1708,7 +1724,7 @@ param(
 			}
 
 		# Get the list of functions to execute.
-		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary4
+		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary4 -lvl $AuditLevelInt
 		# There is nothing to execute.
 		if($listOfFunctions.Count -eq 0)		
 		{
@@ -1782,7 +1798,11 @@ param(
 		$AuditTable,		
 		[parameter(Mandatory=$true, Position=1, ParameterSetName = "Default")]
 		[alias("cp")]		
-		$ComputerParams,				
+		$ComputerParams,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[int]
+		$AuditLevelInt = 1,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dbgl")]
 		[int]
@@ -1830,7 +1850,7 @@ param(
 		}
 		
 		# Get the list of functions to execute.
-		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary5
+		$listOfFunctions = Get-PISysAudit_FunctionsFromLibrary5 -lvl $AuditLevelInt
 		# There is nothing to execute.
 		if($listOfFunctions.Count -eq 0)		
 		{
@@ -4694,7 +4714,12 @@ param(
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dtl")]
 		[boolean]
-		$DetailReport = $true,				
+		$DetailReport = $true,
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]
+		[alias("lvl")]
+		[ValidateSet("Basic", "Verbose")]
+		[string]
+		$AuditLevel = "Basic",
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]		
 		[alias("dbgl")]
 		[int]
@@ -4725,6 +4750,14 @@ PROCESS
 	# Initialize some objects.
 	$ActivityMsg = "Launch analysis on PI System"
 	$statusMsgCompleted = "Completed"
+
+	# Map AuditLevel to the internal AuditLevelInt integer
+	switch($AuditLevel)
+	{
+		"Basic"   { $AuditLevelInt = 1 }
+		"Verbose" { $AuditLevelInt = 8 }
+		default   { $AuditLevelInt = 1 }
+	}
 	
 	# Write the first message in the log file.
 	$msg = "----- Start the audit -----"
@@ -4770,7 +4803,7 @@ PROCESS
 	# ............................................................................................................						
 	$totalCheckCount = $uniqueComputerParamsTable.Count + $ComputerParamsTable.Count
 	$currCheck = 1
-	$ActivityMsg = "Performing PI System Security Audit"
+	$ActivityMsg = "Performing $AuditLevel PI System Security Audit"
 	$statusMsgTemplate = "Checking Role {0}/{1}..."
 	$statusMsgCompleted = "Completed"
 	

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -4663,22 +4663,33 @@ New-PISysAuditReport [[-ComputerParamsTable | -cpt] <hashtable>]
 					 [[-DBGLevel | -dbgl] <int>]
 .INPUTS
 .OUTPUTS
-.PARAMETER cpt
+.PARAMETER ComputerParamsTable
+Alias: -cpt
 Parameter table defining which computers/servers
 to audit and for which PI System components. If a $null
 value is passed or the parameter is skipped, the cmdlet
 will assume to audit the local machine, unless cpf 
 specifies a CSV file.
-.PARAMETER cpf
+.PARAMETER ComputerParametersFile
+Alias: -cpf
 CSV file defining which computers/servers to audit and 
 for which PI System components. Headings must be included 
 in the CSV file.  See example 7 in the conceptual help.
-.PARAMETER obf
+.PARAMETER ObfuscateSensitiveData
+Alias: -obf
 Obfuscate or not the name of computers/servers
 exposed in the audit report.
-.PARAMETER showui
-Output messages on the command prompt or not.
-.PARAMETER dbglevel
+.PARAMETER ShowUI
+Enable or disable message output and progress bar on the command prompt.
+.PARAMETER DetailReport
+Alias: -dtl
+Enable or disable creation of detailed HTML report at end of audit.
+.PARAMETER AuditLevel
+Alias: -lvl
+Choose level of audit to be performed. Higher levels may result
+in slow runtimes.
+.PARAMETER DBGLevel
+Alias: -dbgl
 DebugLevel: 0 for no verbose, 1 for intermediary message
 to help debugging, 2 for full level of details
 .EXAMPLE
@@ -4688,9 +4699,10 @@ The -cpf switch can be used to load parameters from a CSV file
 The -obf switch deactivate the obfuscation of the server name.
 The -dbgl switch sets the debug level to 2 (full debugging)
 .EXAMPLE
-New-PISysAuditReport -cpt $cpt -dbgl 2
+New-PISysAuditReport -cpt $cpt -dbgl 2 -lvl Verbose
 -- See Example 1 for explanations of switch -cpt
 -- The -dbgl switch sets the debug level to 2 (full debugging)
+-- The -lvl switch sets the audit level to 'Verbose'
 .LINK
 https://pisquare.osisoft.com
 #>


### PR DESCRIPTION
Currently:
Basic (mapped to level 1)
Verbose (mapped to level 8)

Mappings for the levels are handled in New-PISysAuditReport, so new ones need only be added there. All GetFunctionsFromLibrary calls will return any checks with level at or below the specified level.