### PR TITLE
Final changes to support constrained language

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
@@ -222,7 +222,7 @@ PROCESS
 		$installVersionTokens = $installVersion.Split(".")
 		# Form an integer value with all the version tokens.
 		[string]$temp = $InstallVersionTokens[0] + $installVersionTokens[1] + $installVersionTokens[2] + $installVersionTokens[3]
-		$installVersionInt64 = [Convert]::ToInt64($temp)
+		$installVersionInt64 = [int64]$temp
 		if($installVersionInt64 -ge 3004)
 		{
 			$result = $true


### PR DESCRIPTION
-Dynamic cast to replace the convert object in lib5
-Alternative method to determine elevated status when using constrained language mode.  It's a hack, but it is 100% safe and applies to every supported OS.
-Use Test-NetConnection for PSv4+. Defer port 5450 check when under constrained mode and powershell 3.  If constrained mode is off and PSv3 is used, net.sockets.tcpclient is fine.  I moved the check to only if the PowerShell Tools connection fails since this check can potentially give more information.  If the PowerShell Tools can connect, testing the port just wastes time.

Fixes #77 

There are a couple nondefault options that will not work in constrained mode.  I created #168 for the documentation.