### PR TITLE
Fixed 3 minor issues

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
@@ -291,14 +291,14 @@ PROCESS
 			$noncompliantTrusts = $noncompliantTrusts | ForEach-Object {$_ + ';'}		
 			$result = $false	
 			$msg = "Trust(s) that present weaknesses: " + $noncompliantTrusts	+ ".`n"
-			$Severity = "severe"
+			$Severity = "Severe"
 		}
 
 		if($noncompliantMappings){
 			$noncompliantMappings =	$noncompliantMappings | ForEach-Object {$_ + ';'}		
 			$result = $false	
 			$msg += "Mappings(s) that present weaknesses: " + $noncompliantMappings																												
-			$Severity = "severe"
+			$Severity = "Severe"
 		}
 
 		if($result -eq $true){
@@ -316,7 +316,7 @@ PROCESS
 			{
 					$result = $false 
 					$msg += "However, the piadmin user can still be assigned to a trust."
-					$Severity = "moderate"
+					$Severity = "Moderate"
 			}
 		}		
 	}

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1337,6 +1337,7 @@ param(
 				{
 					$msgTemplate = "Unable to access the PI AF Server {0} with PowerShell.  Check if there is a valid mapping for your user."
 					$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
+					Write-PISysAudit_LogMessage $msg "Warning" $fn
 					$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
 							-at $AuditTable -an "PI AF Server Audit" -fn $fn -msg $msg
 					return

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1337,7 +1337,8 @@ param(
 				{
 					$msgTemplate = "Unable to access the PI AF Server {0} with PowerShell.  Check if there is a valid mapping for your user."
 					$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
-					Write-PISysAudit_LogMessage $msg "Warning" $fn
+					$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
+							-at $AuditTable -an "PI AF Server Audit" -fn $fn -msg $msg
 					return
 				}
 			}
@@ -4798,7 +4799,7 @@ PROCESS
 		# Initialize.
 		$ComputerParamsTable = @{}
 		
-		if($null -eq $ComputerParametersFile)
+		if($null -eq $ComputerParametersFile -or $ComputerParametersFile -eq "")
 		{
 			# This means an audit on the local computer is required only PI Data Archive and PI AF Server are checked by default.
 			# SQL Server checks ommitted by default as SQL Server will often require an instancename


### PR DESCRIPTION
-Handle empty cpf argument. Fixes #175
-Corrected capitalization inconsistency with severity
-Send AF Connection failure that prevents AF role audit from running to error summary table.