### PR TITLE
Adding check for transport security

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3718,7 +3718,7 @@ PROCESS
 			{
 				$connectedTime = $(Get-Date $PIConnection.ConnectedTime)
 				# Message ID 7082 corresponds to a successful connection with Windows
-				$connectionMessages = Get-PIMessage -StartTime $connectedTime.AddSeconds(-1*$timeBuffer) -EndTime $connectedTime.AddSeconds($timeBuffer) -Id 7082 -Program pinetmgr
+				$connectionMessages = Get-PIMessage -Connection $PIDataArchiveConnection -StartTime $connectedTime.AddSeconds(-1*$timeBuffer) -EndTime $connectedTime.AddSeconds($timeBuffer) -Id 7082 -Program pinetmgr
 				foreach($message in $connectionMessages)
 				{
 					# Extract the connection ID

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1710,7 +1710,7 @@ PROCESS
 		New-Variable -Name "PISysAuditIsElevated" -Scope "Global" -Visibility "Public" -Value $IsElevated
 
 		# Validate if used with PowerShell version 3.x and more	
-		$majorVersionPS = $Host.Version.Major	
+		$majorVersionPS = $PSVersionTable.PSVersion.Major	
 		if($majorVersionPS -lt 3)
 		{						
 			$msg = "This script won't execute under less than version 3.0 of PowerShell"


### PR DESCRIPTION
Introduced AU20012 with Get-PISysAudit_CheckTransportSecurity in the PI Data Archive library to check if remote connections are using transport security.  Test-PISysAudit_SecurePIConnections contains the logic for setting the SecureStatus and SecureStatusDetail on each connection statistic

Fixes #184 

Initialize-PISysAudit now examines the PS Version Table. 

Fixes #185 