### PR TITLE
Sort results table by machine within severity

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -4594,7 +4594,10 @@ PROCESS
 		}
 		
 		# Export to .csv but sort the results table first to have Failed items on the top sorted by Severity 
-		$results = $results | Sort-Object @{Expression="AuditItemValue";Descending=$false},@{Expression="Severity";Descending=$true},@{Expression="ID";Descending=$false}
+		$results = $results | Sort-Object   @{Expression="AuditItemValue";Descending=$false}, `
+											@{Expression="Severity";Descending=$true}, `
+											@{Expression="ServerName";Descending=$false}, `
+											@{Expression="ID";Descending=$false}
 		$results | Export-Csv -Path $fileToExport -Encoding ASCII -NoType
 	
 		


### PR DESCRIPTION
Changed HTML report results table to sort by machine within each
severity level so that it is possible to quickly glance at how many
results of each severity were returned for a machine.

Closes #190