### PR TITLE
Fix 195, 197, progress bars

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -2652,7 +2652,7 @@ PROCESS
 	
 	try
 	{
-		if($PSVersionTable.PSVersion.Major -ge 4)
+		if(Get-Command Resolve-DnsName -ErrorAction SilentlyContinue)
 		{
 			$record = Resolve-DnsName -Name $LookupName 
 			$recordObjectType = $record.GetType().Name
@@ -3029,7 +3029,7 @@ PROCESS
 	{									
 		if($LocalComputer)
 		{			                    			
-			$firewallState = Get-NetFirewallProfile 
+			$firewallState = Get-NetFirewallProfile
 		}
 		else
 		{                            				

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1053,7 +1053,10 @@ param(
 		}			
 		# Set the progress.
 		if($ShowUI)
-		{ Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -completed }
+		{ 
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -PercentComplete 100 
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -Completed 
+		}
 	}
 	catch
 	{
@@ -1211,7 +1214,10 @@ param(
 
 		# Set the progress.
 		if($ShowUI)
-		{ Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -completed }
+		{ 
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -PercentComplete 100 
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -Completed
+		}
 	}
 	catch
 	{
@@ -1381,7 +1387,10 @@ param(
 
 		# Set the progress.
 		if($ShowUI)
-		{ Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -completed }
+		{ 
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -PercentComplete 100
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -Completed
+		}
 	}
 	catch
 	{
@@ -1527,7 +1536,10 @@ param(
 		}
 		# Set the progress.
 		if($ShowUI)
-		{ Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -completed }
+		{
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -PercentComplete 100
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -Completed
+		}
 	}
 	catch
 	{
@@ -1661,7 +1673,10 @@ param(
 		}
 		# Set the progress.
 		if($ShowUI)
-		{ Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -completed }
+		{ 
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -PercentComplete 100
+			Write-Progress -activity $activityMsg1 -Status $statusMsgCompleted -ParentId 1 -Completed 
+		}
 	}
 	catch
 	{
@@ -5189,6 +5204,7 @@ PROCESS
 			$currCheck += $item.Value.Count
 		}
 	}
+	Write-Progress -Activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -PercentComplete 100 
 	Write-Progress -Activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -Completed
 
 	# Pad console ouput with one line
@@ -5200,7 +5216,11 @@ PROCESS
 	$ActivityMsg = "Generate report"
 	if($ShowUI) { Write-Progress -activity $ActivityMsg -Status "in progress..." -Id 1 }
 	$reportName = Write-PISysAuditReport $auditHashTable -obf $ObfuscateSensitiveData -dtl $DetailReport -dbgl $DBGLevel
-	if($ShowUI) { Write-Progress -activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -completed }
+	if($ShowUI) 
+	{ 
+		Write-Progress -activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -PercentComplete 100
+		Write-Progress -activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -Completed 
+	}
 	
 	# ............................................................................................................
 	# Display that the analysis is completed and where the report can be found.


### PR DESCRIPTION
Use get-command to check for Resolve-DnsName: Fixes #197

Update Get-PISysAudit_FirewallState: Added support for Win7 and Win2008, which do not support the
Get-NetFirewallProfile cmdlet even on Powershell 3.0. If the command is not found, registry keys will be used to return the profile states. Fixes #195

Fix lingering progress bars: Progress bars will linger in Visual Studio if the -Completed flag is
used before -PercentComplete is set to 100. Did not seem to cause a problem in other Powershell hosts.