### PR TITLE
Added manual time offset for AU20012

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
@@ -1265,7 +1265,8 @@ PROCESS
 		if($version.Major -ge 3 -and $version.Minor -ge 4 -and $version.Build -ge 395)
 		{
 			$rawPIConnectionStats = Get-PIConnectionStatistics -Connection $global:PIDataArchiveConnection
-			$processedPIConnectionStats = Get-PISysAudit_ProcessedPIConnectionStatistics -PIDataArchiveConnection $global:PIDataArchiveConnection `
+			$processedPIConnectionStats = Get-PISysAudit_ProcessedPIConnectionStatistics -lc $LocalComputer -rcn $RemoteComputerName `
+																					-PIDataArchiveConnection $global:PIDataArchiveConnection `
 																					-PIConnectionStats $rawPIConnectionStats -ProtocolFilter Any `
 																					-RemoteOnly $true -SuccessOnly $true -CheckTransportSecurity $true `
 																					-DBGLevel $DBGLevel


### PR DESCRIPTION
Get-PIConnectionStatistics returns times in string format, in the
timezone of the PI Data Archive. Updated
Get-PISysAudit_ProcessedPIConnectionStatistics to convert these to
DateTime and apply an offset according to the relative time zone of the
PI Data Archive machine.

Fixes #207