### PR TITLE
Updated Lib5 to support PI Vision

### DIFF
--- a/PISecurityAudit/Scripts/Examples.ps1
+++ b/PISecurityAudit/Scripts/Examples.ps1
@@ -32,7 +32,7 @@ piaudit
 $cpt = piauditparams $null "myPIServer" "PIDataArchive"
 $cpt = piauditparams $cpt "myPIAFServer" "PIAFServer"
 $cpt = piauditparams $cpt "mySQLServer" "SQLServer" -InstanceName "myinstance" # -IntegratedSecurity $false -user "sa" -pf "p1.dat"
-$cpt = piauditparams $cpt "myCoresight" "PICoresightServer"
+$cpt = piauditparams $cpt "myPIVision" "PIVisionServer"
 piaudit -cpt $cpt
 
 # Example 3
@@ -44,7 +44,7 @@ pwdondisk
 $cpt = piauditparams $null "myPIServer" "PIDataArchive"
 $cpt = piauditparams $cpt "myPIAFServer" "PIAFServer"
 $cpt = piauditparams $cpt "mySQLServer" "SQLServer" -InstanceName "myinstance" -IntegratedSecurity $false -user "sa" -pf "p1.dat"
-$cpt = piauditparams $cpt "myCoresight" "PICoresightServer"
+$cpt = piauditparams $cpt "myPIVision" "PIVisionServer"
 piaudit -cpt $cpt
 
 # Example 4
@@ -53,7 +53,7 @@ piaudit -cpt $cpt
 $cpt = piauditparams $null "myPIServer" "PIDataArchive"
 $cpt = piauditparams $cpt "myPIAFServer" "PIAFServer"
 $cpt = piauditparams $cpt "mySQLServer" "SQLServer" -InstanceName "myinstance" -IntegratedSecurity $false -user "sa"
-$cpt = piauditparams $cpt "myCoresight" "PICoresightServer"
+$cpt = piauditparams $cpt "myPIVision" "PIVisionServer"
 piaudit -cpt $cpt
 
 # Example 5

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
@@ -3,7 +3,7 @@
 # ***********************************************************************
 # * Modulename:   PISYSAUDIT
 # * Filename:     PISYSAUDITCHECKLIB5.psm1
-# * Description:  Validation rules for PI Coresight.
+# * Description:  Validation rules for PI Vision.
 # *
 # * Copyright 2016 OSIsoft, LLC
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,7 @@ function Get-PISysAudit_FunctionsFromLibrary5
 {
 <#  
 .SYNOPSIS
-Get functions from Coresight library at or below the specified level.
+Get functions from PI Vision library at or below the specified level.
 #>
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
 param(
@@ -62,20 +62,20 @@ param(
 	# Form a list of all functions that need to be called to test
 	# the machine compliance.
 	$listOfFunctions = @()
-	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckCoresightVersion"  1 # AU50001
-	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckCoresightAppPools" 1 # AU50002
-	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CoresightSSLcheck"      1 # AU50003
-	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CoresightSPNcheck"      1 # AU50004
+	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckPIVisionVersion"  1 # AU50001
+	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckPIVisionAppPools" 1 # AU50002
+	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckPIVisionSSL"      1 # AU50003
+	$listOfFunctions += NewAuditFunction "Get-PISysAudit_CheckPIVisionSPN"      1 # AU50004
 	
 	# Return all items at or below the specified AuditLevelInt
 	return $listOfFunctions | Where-Object Level -LE $AuditLevelInt
 }
 
-function Get-PISysAudit_GlobalPICoresightConfiguration
+function Get-PISysAudit_GlobalPIVisionConfiguration
 {
 <#  
 .SYNOPSIS
-Gathers global data for all Coresight checks.
+Gathers global data for all PI Vision checks.
 .DESCRIPTION
 Several checks reuse information.  This command puts the configuration information
 in a global object to reduce the number of remote calls, improving performance and 
@@ -117,24 +117,31 @@ PROCESS
 	$fn = GetFunctionName
 
 	# Reset global config object.
-	$global:CoresightConfiguration = $null
+	$global:PIVisionConfiguration = $null
 	
 	$scriptBlock = {
-			$ProductName = 'Coresight'
 			Import-Module WebAdministration
 			
+			$pisystemKey = "HKLM:\Software\PISystem\"
+			if(Test-Path -Path $($pisystemKey + "PIVision"))
+			{ $ProductName = 'PIVision' }
+			elseif(Test-Path -Path $($pisystemKey + "Coresight"))
+			{ $ProductName = 'Coresight' }
+			else
+			{ Write-PISysAudit_LogMessage "Product registry key not found." "Error" $fn }
+
 			# Registry keys
-			$Version = Get-ItemProperty -Path "HKLM:\Software\PISystem\Coresight" -Name "CurrentVersion" | Select-Object -ExpandProperty "CurrentVersion"
+			$Version = Get-ItemProperty -Path $($pisystemKey + $ProductName) -Name "CurrentVersion" | Select-Object -ExpandProperty "CurrentVersion"
 			$MachineDomain = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\services\Tcpip\Parameters" -Name "Domain" | Select-Object -ExpandProperty "Domain"
 			$Hostname = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName" -Name "ComputerName" | Select-Object -ExpandProperty "ComputerName"
-			$Site = Get-ItemProperty -Path $("HKLM:\Software\PISystem\" + $ProductName) -Name "WebSite" | Select-Object -ExpandProperty "WebSite"
+			$Site = Get-ItemProperty -Path $($pisystemKey + $ProductName) -Name "WebSite" | Select-Object -ExpandProperty "WebSite"
 			
 			# IIS Configuration
 			$Bindings = Get-WebBinding -Name $Site
 			$UsingHTTPS = $Bindings.protocol -contains "https"
 			$sslFlagsSite = Get-WebConfigurationProperty -Location $($Site.ToString()) -Filter system.webServer/security/access -Name "sslFlags"
-			$sslFlagsApp = Get-WebConfigurationProperty -Location $($Site.ToString() + '/Coresight') -Filter system.webServer/security/access -Name "sslFlags"
-			$BasicAuthEnabled = Get-WebConfigurationProperty -Filter /system.webServer/security/authentication/BasicAuthentication -Name Enabled -location $($Site + '/Coresight') | select-object Value	
+			$sslFlagsApp = Get-WebConfigurationProperty -Location $($Site.ToString() + '/' + $ProductName) -Filter system.webServer/security/access -Name "sslFlags"
+			$BasicAuthEnabled = Get-WebConfigurationProperty -Filter /system.webServer/security/authentication/BasicAuthentication -Name Enabled -location $($Site.ToString() + '/' + $ProductName) | select-object Value	
 			
 			# App Pool Info 
 			$ServiceAppPoolType = Get-ItemProperty $('iis:\apppools\' + $ProductName + 'serviceapppool') -Name processmodel.identitytype
@@ -144,6 +151,7 @@ PROCESS
 			
 			# Construct a custom object to store the config information
 			$Configuration = New-Object PSCustomObject
+			$Configuration | Add-Member -MemberType NoteProperty -Name ProductName -Value $ProductName
 			$Configuration | Add-Member -MemberType NoteProperty -Name Version -Value $Version
 			$Configuration | Add-Member -MemberType NoteProperty -Name Hostname -Value $Hostname
 			$Configuration | Add-Member -MemberType NoteProperty -Name MachineDomain -Value $MachineDomain
@@ -163,14 +171,14 @@ PROCESS
 	try
 	{
 		if($LocalComputer)
-		{ $global:CoresightConfiguration = & $scriptBlock }
+		{ $global:PIVisionConfiguration = & $scriptBlock }
 		else
-		{ $global:CoresightConfiguration = Invoke-Command -ComputerName $RemoteComputerName -ScriptBlock $scriptBlock }
+		{ $global:PIVisionConfiguration = Invoke-Command -ComputerName $RemoteComputerName -ScriptBlock $scriptBlock }
 	}
 	catch
 	{
 		# Return the error message.
-		$msg = "A problem occurred during the retrieval of the Global Coresight configuration."					
+		$msg = "A problem occurred during the retrieval of the Global PI Vision configuration."					
 		Write-PISysAudit_LogMessage $msg "Error" $fn -eo $_									
 		$result = "N/A"
 	}
@@ -179,14 +187,14 @@ END {}
 
 }
 
-function Get-PISysAudit_CheckCoresightVersion
+function Get-PISysAudit_CheckPIVisionVersion
 {
 <#  
 .SYNOPSIS
-AU50001 - Check for latest version of Coresight
+AU50001 - Check for latest version of PI Vision
 .DESCRIPTION
-VALIDATION: verifies PI Coresight version.<br/>
-COMPLIANCE: upgrade to the latest version of PI Coresight.  For more information, 
+VALIDATION: verifies PI Vision version.<br/>
+COMPLIANCE: upgrade to the latest version of PI Vision.  For more information, 
 see "Upgrade a PI Coresight installation" in the PI Live Library.<br/>
 <a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6">https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6</a>
 #>
@@ -217,7 +225,7 @@ PROCESS
 	
 	try
 	{		
-		$installVersion = $global:CoresightConfiguration.Version	
+		$installVersion = $global:PIVisionConfiguration.Version	
 		
 		$installVersionTokens = $installVersion.Split(".")
 		# Form an integer value with all the version tokens.
@@ -246,8 +254,8 @@ PROCESS
 	$AuditTable = New-PISysAuditObject -lc $LocalComputer -rcn $RemoteComputerName `
 									-at $AuditTable "AU50001" `
 									-aif $fn -msg $msg `
-									-ain "PI Coresight Version" -aiv $result `
-									-Group1 "PI System" -Group2 "PI Coresight" `
+									-ain "PI Vision Version" -aiv $result `
+									-Group1 "PI System" -Group2 "PI Vision" `
 									-Severity "Medium"																																																
 
 }
@@ -259,13 +267,13 @@ END {}
 #***************************
 }
 
-function Get-PISysAudit_CheckCoresightAppPools
+function Get-PISysAudit_CheckPIVisionAppPools
 {
 <#  
 .SYNOPSIS
-AU50002 - Check Coresight AppPools identity
+AU50002 - Check PI Vision AppPools identity
 .DESCRIPTION
-VALIDATION: checks PI Coresight AppPool identity.<br/>
+VALIDATION: checks PI Vision AppPool identity.<br/>
 COMPLIANCE: Use a custom domain account. Network Service is acceptable, but not ideal. 
 For more information, see "Create a service account for PI Coresight" in the PI Live Library. <br/>
 <a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-A790D013-BAC8-405B-A017-33E55595B411">https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-A790D013-BAC8-405B-A017-33E55595B411</a>
@@ -296,12 +304,12 @@ PROCESS
 	
 	try
 	{	
-		$ServiceAppPoolType = $global:CoresightConfiguration.ServiceAppPoolType   # Service AppPool Identity Type
-		$AdminAppPoolType = $global:CoresightConfiguration.AdminAppPoolType       # Admin AppPool Identity Type 
-		$ServiceAppPoolUser = $global:CoresightConfiguration.ServiceAppPoolUser   # Service AppPool User
-		$AdminAppPoolUser = $global:CoresightConfiguration.AdminAppPoolUser       # Admin AppPool User
+		$ServiceAppPoolType = $global:PIVisionConfiguration.ServiceAppPoolType   # Service AppPool Identity Type
+		$AdminAppPoolType = $global:PIVisionConfiguration.AdminAppPoolType       # Admin AppPool Identity Type 
+		$ServiceAppPoolUser = $global:PIVisionConfiguration.ServiceAppPoolUser   # Service AppPool User
+		$AdminAppPoolUser = $global:PIVisionConfiguration.AdminAppPoolUser       # Admin AppPool User
 		
-		# Both Coresight AppPools must run under the same identity.
+		# Both AppPools must run under the same identity.
 		If ( $ServiceAppPoolType -eq $AdminAppPoolType -and $ServiceAppPoolUser -eq $AdminAppPoolUser ) 
 		{ 
 			# If a custom account is used, we need to distinguish between a local and domain account.
@@ -311,11 +319,11 @@ PROCESS
 				If ($ServiceAppPoolUser -contains ".\" ) 
 				{ 
 					$result = $false
-					$msg =  "Local User is running Coresight AppPools. Please use a custom domain account."
+					$msg =  "Local User is running PI Vision AppPools. Please use a custom domain account."
 				}
 				Else # At this point, it's either a domain account or local account using "HOSTNAME\user" format. 
 				{
-					$hostname = $global:CoresightConfiguration.Hostname # Web Server Hostname
+					$hostname = $global:PIVisionConfiguration.Hostname # Web Server Hostname
 					# Extract the domain part from the AppPool identity string.
 					$ServiceAppPoolUserDomain = $ServiceAppPoolUser.Split("\")[0]
 
@@ -323,32 +331,32 @@ PROCESS
 					If ($hostname -eq $ServiceAppPoolUserDomain)
 					{
 						$result = $false
-						$msg =  "Local User is running Coresight AppPools. Please use a custom domain account."
+						$msg =  "Local User is running PI Vision AppPools. Please use a custom domain account."
 					}
 					Else # A custom domain account is used. 
 					{
 						$result = $true
-						$msg =  "A custom domain account is running both Coresight AppPools"
+						$msg =  "A custom domain account is running both PI Vision AppPools"
 					}
 				}
 
 			}
-			ElseIf ($ServiceAppPoolType -eq "LocalSystem" ) # LocalSystem is running the Coresight AppPools. That's a bad idea.
+			ElseIf ($ServiceAppPoolType -eq "LocalSystem" ) # LocalSystem is running the AppPools. That's a bad idea.
 			{ 
 				$result = $false
-				$msg =  "Local System is running both Coresight AppPools. Use a custom domain account instead."
+				$msg =  "Local System is running both PI Vision AppPools. Use a custom domain account instead."
 			}
 			Else # The only other options are: LocalService, NetworkService and AppPoolIdentity.  Pass and recommend domain account.
 			{
 				$result = $true
-				$msg =  $ServiceAppPoolType + " is running the Coresight AppPools. Use a custom domain account instead."
+				$msg =  $ServiceAppPoolType + " is running the PI Vision AppPools. Use a custom domain account instead."
 
 			}
 		}
-		Else # For technical reasons, both Coresight AppPools must run under the same identity.
+		Else # For technical reasons, both AppPools must run under the same identity.
 		{
 			$result = $false
-			$msg = "Both Coresight AppPools must run under the same identity."
+			$msg = "Both PI Vision AppPools must run under the same identity."
 		}
 	}
 	catch
@@ -363,8 +371,8 @@ PROCESS
 	$AuditTable = New-PISysAuditObject -lc $LocalComputer -rcn $RemoteComputerName `
 									-at $AuditTable "AU50002" `
 									-aif $fn -msg $msg `
-									-ain "PI Coresight AppPool Check" -aiv $result `
-									-Group1 "PI System" -Group2 "PI Coresight" `
+									-ain "PI Vision AppPool Check" -aiv $result `
+									-Group1 "PI System" -Group2 "PI Vision" `
 									-Severity "Medium"																																																
 }
 
@@ -375,13 +383,13 @@ END {}
 #***************************
 }
 
-function Get-PISysAudit_CoresightSSLcheck
+function Get-PISysAudit_CheckPIVisionSSL
 {
 <#  
 .SYNOPSIS
-AU50003 - Coresight SSL check
+AU50003 - PI Vision SSL check
 .DESCRIPTION
-VALIDATION: Checks whether SSL is enabled and enforced on the Coresight Web Site.<br/>
+VALIDATION: Checks whether SSL is enabled and enforced on the PI Vision Web Site.<br/>
 COMPLIANCE: A valid HTTPS binding is configured and only connections with SSL are allowed. The SSL certificate is issued by a Certificate Authority.
 For more information, see "Configure Secure Sockets Layer (SSL) access" in the PI Live Library. <br/>
 <a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-CB46B733-264B-48D3-9033-73D16B4DBD3B">https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-CB46B733-264B-48D3-9033-73D16B4DBD3B</a>
@@ -412,9 +420,9 @@ PROCESS
 	$severity = "Unknown"
 	try
 	{	
-		$CSwebSite = $global:CoresightConfiguration.WebSite # Web Site name
-		$WebBindings = $global:CoresightConfiguration.Bindings # Web Site bindings
-		$httpsBindingConfigured = $global:CoresightConfiguration.UsingHTTPS # Check if HTTPS binding is enabled.
+		$CSwebSite = $global:PIVisionConfiguration.WebSite # Web Site name
+		$WebBindings = $global:PIVisionConfiguration.Bindings # Web Site bindings
+		$httpsBindingConfigured = $global:PIVisionConfiguration.UsingHTTPS # Check if HTTPS binding is enabled.
 
 		# HTTPS binding is disabled, so there's no point in checking anything else.
 		If ($httpsBindingConfigured = $false) 
@@ -422,7 +430,7 @@ PROCESS
 			# Test fails, but how epic is the fail?
 			$result = $false
 
-			$basicAuth = $global:CoresightConfiguration.BasicAuthEnabled # Check if Basic Authentication is enabled.
+			$basicAuth = $global:PIVisionConfiguration.BasicAuthEnabled # Check if Basic Authentication is enabled.
 			# Basic Authentication is disabled.
 			If ($basicAuth.Value -eq $False) 
 			{ 
@@ -437,27 +445,27 @@ PROCESS
 		} 
 		Else # HTTPS binding is enabled.
 		{ 
-			$SSLCheck_WebSite = $global:CoresightConfiguration.sslFlagsSite # SSL setting at Web Site level
-			$SSLCheck_WebApp = $global:CoresightConfiguration.sslFlagsApp # SSL setting at Web App level
+			$SSLCheck_WebSite = $global:PIVisionConfiguration.sslFlagsSite # SSL setting at Web Site level
+			$SSLCheck_WebApp = $global:PIVisionConfiguration.sslFlagsApp # SSL setting at Web App level
 
 			# If either the Web Site OR Web App allows only connections with SSL, it's OK.
 			If ($SSLCheck_WebSite.ToString() -eq "Ssl" -or $SSLCheck_WebApp.ToString() -eq "Ssl") 
 			{ 
 				# SSL is correctly configured. Let's check whether the SSL certificate is issued by a CA.
-				$MachineDomain = $global:CoresightConfiguration.MachineDomain # Web Server Machine Domain
-				$hostname = $global:CoresightConfiguration.Hostname # Web Server Hostname.
+				$MachineDomain = $global:PIVisionConfiguration.MachineDomain # Web Server Machine Domain
+				$hostname = $global:PIVisionConfiguration.Hostname # Web Server Hostname.
 
 				# Build FQDN using hostname and domain strings.
 				$fqdn = $hostname + "." + $machineDomain
 
-				# Get the issuer of the SSL certificate used on the Coresight Web Site.
+				# Get the issuer of the SSL certificate used on the Web Site.
 				$matches = [regex]::Matches($WebBindings, 'https \*:([0-9]+):') 
 				
 				# Go through all bindings.
 				foreach ($match in $matches) {
 
 					$port = $($match.Groups[1].Captures[0].Value)
-					# Find SSL certificate for each binding of the PI Coresight Web Site.
+					# Find SSL certificate for each binding of the Web Site.
 					$portCert = Get-PISysAudit_BoundCertificate -lc $LocalComputer -rcn $RemoteComputerName -Port $port -DBGLevel $DBGLevel
 					
 					# Get the Thumbprint from all SSL certificates that have been found.
@@ -488,7 +496,7 @@ PROCESS
 				# Test fails, but how epic is the fail?
 				$result = $false
 				
-				$basicAuth = $global:CoresightConfiguration.BasicAuthEnabled # Check if Basic Authentication is enabled.
+				$basicAuth = $global:PIVisionConfiguration.BasicAuthEnabled # Check if Basic Authentication is enabled.
 				# Basic Authentication is disabled. Not too bad.
 				If ($basicAuth.Value -eq $False) 
 				{ 
@@ -515,8 +523,8 @@ PROCESS
 	$AuditTable = New-PISysAuditObject -lc $LocalComputer -rcn $RemoteComputerName `
 									-at $AuditTable "AU50003" `
 									-aif $fn -msg $msg `
-									-ain "PI Coresight SSL Check" -aiv $result `
-									-Group1 "PI System" -Group2 "PI Coresight" `
+									-ain "PI Vision SSL Check" -aiv $result `
+									-Group1 "PI System" -Group2 "PI Vision" `
 									-Severity $severity																																															
 }
 
@@ -527,14 +535,14 @@ END {}
 #***************************
 }
 
-function Get-PISysAudit_CoresightSPNcheck
+function Get-PISysAudit_CheckPIVisionSPN
 {
 <#  
 .SYNOPSIS
-AU50004 - Coresight SPN check
+AU50004 - PI Vision SPN check
 .DESCRIPTION
-VALIDATION: Checks PI Coresight SPN assignment. <br/>
-COMPLIANCE: HTTP or HOST SPNs exist and are assigned to the Coresight AppPool account. This makes Kerberos Authentication possible.
+VALIDATION: Checks PI Vision SPN assignment. <br/>
+COMPLIANCE: HTTP or HOST SPNs exist and are assigned to the PI Vision AppPool account. This makes Kerberos Authentication possible.
 For more information, see the PI Live Library link below. <br/>
 <a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-68329569-D75C-406D-AE2D-9ED512E74D46">https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-68329569-D75C-406D-AE2D-9ED512E74D46</a>
 #>
@@ -564,17 +572,16 @@ PROCESS
 	
 	try
 	{		
-		$ServiceAppPoolType = $global:CoresightConfiguration.ServiceAppPoolType  # Service AppPool Identity Type 
-		$ServiceAppPoolUser = $global:CoresightConfiguration.ServiceAppPoolUser  # Service AppPool User
-		$CSwebSite = $global:CoresightConfiguration.WebSite  # Web Site Name
-		$WebBindings = $global:CoresightConfiguration.Bindings # Web Site bindings.
+		$ServiceAppPoolType = $global:PIVisionConfiguration.ServiceAppPoolType  # Service AppPool Identity Type 
+		$ServiceAppPoolUser = $global:PIVisionConfiguration.ServiceAppPoolUser  # Service AppPool User
+		$WebBindings = $global:PIVisionConfiguration.Bindings # Web Site bindings.
 
-		# Coresight is using the http service class.
+		# Using the http service class.
 		$serviceType = "http"
 
-		# Special 'service name' for Coresight.
-		# This is needed to distinguish between SPN check for IIS Apps such as Coresight, and Windows Services such as PI or AF.
-		$serviceName = "coresight"
+		# Special 'service name' for PI Vision.
+		# This is needed to distinguish between SPN check for IIS Apps such as PI Vision, and Windows Services such as PI or AF.
+		$serviceName = "pivision"
 
 		# Converting the binding info to a string. Otherwise $matches based on RegExps are not returned correctly.
 		$BindingsToString = $($WebBindings) | Out-String
@@ -585,29 +592,29 @@ PROCESS
 		# Go through all bindings.
 		foreach ($match in $matches) 
 		{
-			$CSheader = $match.Groups[1].Captures[0].Value 				
-			If ($CSheader) # A custom host header is used!
+			$CustomHeader = $match.Groups[1].Captures[0].Value 				
+			If ($CustomHeader) # A custom host header is used!
 			{ 
-				$serviceName = "coresight_custom"
+				$serviceName = "pivision_custom"
 				break 
 			}
 		}
 
-		# Coresight is running under a custom domain account.
+		# AppPool is running under a custom domain account.
 		If ( $ServiceAppPoolType -eq "SpecificUser") 
 		{ 
-			$csappPool = $ServiceAppPoolUser 
+			$AppPool = $ServiceAppPoolUser 
 		} 
-		# Coresight is running under a machine account.
+		# AppPool is running under a machine account.
 		Else 
 		{ 
-			$csappPool = $ServiceAppPoolType
+			$AppPool = $ServiceAppPoolType
 
 			# Machine accounts don't need HTTP service class - it's already included in the HOST service class.
 			$serviceType = "host"
 		}
 		
-		$result = Invoke-PISysAudit_SPN -svctype $serviceType -svcname $serviceName -lc $LocalComputer -rcn $RemoteComputerName -appPool $csappPool -CustomHeader $CSheader -dbgl $DBGLevel
+		$result = Invoke-PISysAudit_SPN -svctype $serviceType -svcname $serviceName -lc $LocalComputer -rcn $RemoteComputerName -AppPool $AppPool -CustomHeader $CustomHeader -dbgl $DBGLevel
 
 		if($null -eq $result)
 		{
@@ -638,8 +645,8 @@ PROCESS
 	$AuditTable = New-PISysAuditObject -lc $LocalComputer -rcn $RemoteComputerName `
 									-at $AuditTable "AU50004" `
 									-aif $fn -msg $msg `
-									-ain "PI Coresight SPN Check" -aiv $result `
-									-Group1 "PI System" -Group2 "PI Coresight" `
+									-ain "PI Vision SPN Check" -aiv $result `
+									-Group1 "PI System" -Group2 "PI Vision" `
 									-Severity "Medium"																																																
 }
 
@@ -691,7 +698,7 @@ PROCESS
 	try
 	{		
 		# Enter routine.
-		# Use information from $global:CoresightConfiguration whenever possible to 
+		# Use information from $global:PIVisionConfiguration whenever possible to 
 		# focus on validation simplify logic. 		
 	}
 	catch
@@ -723,12 +730,12 @@ END {}
 # Export Module Member
 # ........................................................................
 # <Do not remove>
-Export-ModuleMember Get-PISysAudit_GlobalPICoresightConfiguration
+Export-ModuleMember Get-PISysAudit_GlobalPIVisionConfiguration
 Export-ModuleMember Get-PISysAudit_FunctionsFromLibrary5
-Export-ModuleMember Get-PISysAudit_CheckCoresightVersion
-Export-ModuleMember Get-PISysAudit_CheckCoresightAppPools
-Export-ModuleMember Get-PISysAudit_CoresightSSLcheck
-Export-ModuleMember Get-PISysAudit_CoresightSPNcheck
+Export-ModuleMember Get-PISysAudit_CheckPIVisionVersion
+Export-ModuleMember Get-PISysAudit_CheckPIVisionAppPools
+Export-ModuleMember Get-PISysAudit_CheckPIVisionSSL
+Export-ModuleMember Get-PISysAudit_CheckPIVisionSPN
 # </Do not remove>
 
 # ........................................................................

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -666,7 +666,7 @@ param(
 	{ return $false }
 }
 
-function ValidateIfHasPICoresightRole
+function ValidateIfHasPIVisionRole
 {
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
 param(		
@@ -688,8 +688,14 @@ param(
 	try
 	{
 		$result = $false
-		$RegKeyPath = "HKLM:\Software\PISystem\Coresight"
-		$result = Get-PISysAudit_TestRegistryKey -lc $LocalComputer -rcn $RemoteComputerName -rkp $RegKeyPath -DBGLevel $DBGLevel						
+		$RegKeyPath = "HKLM:\Software\PISystem\PIVision"
+		$result = Get-PISysAudit_TestRegistryKey -lc $LocalComputer -rcn $RemoteComputerName -rkp $RegKeyPath -DBGLevel $DBGLevel	
+		# If PI Vision is not present, check for previous name. 
+		if($result -eq $false)
+		{
+			$RegKeyPath = "HKLM:\Software\PISystem\Coresight"
+			$result = Get-PISysAudit_TestRegistryKey -lc $LocalComputer -rcn $RemoteComputerName -rkp $RegKeyPath -DBGLevel $DBGLevel
+		}					
 		return $result
 	}
 	catch
@@ -1551,7 +1557,7 @@ param(
 	}		
 }
 
-function StartPICoresightServerAudit
+function StartPIVisionServerAudit
 {
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]
 param(										
@@ -1581,14 +1587,14 @@ param(
 		$IsElevated = (Get-Variable "PISysAuditIsElevated" -Scope "Global" -ErrorAction "SilentlyContinue").Value	
 			
 		# Validate the presence of IIS
-		if((ValidateIfHasPICoresightRole -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName -dbgl $DBGLevel) -eq $false)
+		if((ValidateIfHasPIVisionRole -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName -dbgl $DBGLevel) -eq $false)
 		{
 			# Return the error message.
-			$msgTemplate = "The computer {0} does not have the PI Coresight role or the validation failed"
+			$msgTemplate = "The computer {0} does not have the PI Vision role or the validation failed"
 			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
 			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
+							-at $AuditTable -an "PI Vision Server Audit" -fn $fn -msg $msg
 			return
 		}
 
@@ -1597,7 +1603,7 @@ param(
 			$msg = "Elevation required to run Audit checks using IIS Cmdlet.  Run PowerShell as Administrator to complete these checks."
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
 			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
+							-at $AuditTable -an "PI Vision Server Audit" -fn $fn -msg $msg
 			return
 		}
 
@@ -1608,12 +1614,12 @@ param(
 			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
 			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
+							-at $AuditTable -an "PI Vision Server Audit" -fn $fn -msg $msg
 			return
 		}
 
 		# Set message templates.
-		$activityMsgTemplate1 = "Check PI Coresight component on '{0}' computer"
+		$activityMsgTemplate1 = "Check PI Vision component on '{0}' computer"
 		$activityMsg1 = [string]::Format($activityMsgTemplate1, $ComputerParams.ComputerName)
 		$statusMsgProgressTemplate1 = "Perform check {0}/{1}: {2}"
 		$statusMsgCompleted = "Completed"
@@ -1623,17 +1629,17 @@ param(
 
 		try
 		{
-			Write-Progress -Activity $activityMsg1 -Status "Gathering Coresight Configuration" -ParentId 1
-			Get-PISysAudit_GlobalPICoresightConfiguration -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName -DBGLevel $DBGLevel 
+			Write-Progress -Activity $activityMsg1 -Status "Gathering PI Vision Configuration" -ParentId 1
+			Get-PISysAudit_GlobalPIVisionConfiguration -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName -DBGLevel $DBGLevel 
 		}
 		catch
 		{
 			# Return the error message.
-			$msgTemplate = "An error occurred while accessing the global configuration of PI Coresight on {0}"
+			$msgTemplate = "An error occurred while accessing the global configuration of PI Vision on {0}"
 			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
 			$AuditTable = New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-							-at $AuditTable -an "PI Coresight Server Audit" -fn $fn -msg $msg
+							-at $AuditTable -an "PI Vision Server Audit" -fn $fn -msg $msg
 			return
 		}
 
@@ -1643,7 +1649,7 @@ param(
 		if($listOfFunctions.Count -eq 0)		
 		{
 			# Return the error message.
-			$msg = "No PI Coresight checks have been found."
+			$msg = "No PI Vision checks have been found."
 			Write-PISysAudit_LogMessage $msg "Warning" $fn
 			return
 		}							
@@ -1683,7 +1689,7 @@ param(
 	catch
 	{
 		# Return the error message.
-		$msg = "A problem occurred during the processing of PI Coresight checks"					
+		$msg = "A problem occurred during the processing of PI Vision checks"					
 		Write-PISysAudit_LogMessage $msg "Error" $fn -eo $_				
 		return
 	}		
@@ -3584,13 +3590,11 @@ param(
 		[string]
 		$ServiceType,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
-		[alias("appPool")]
 		[string]
-		$csappPool,
+		$AppPool,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
-		[alias("CustomHeader")]
 		[string]
-		$CoresightHeader,
+		$CustomHeader,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("dbgl")]
 		[int]
@@ -3611,28 +3615,28 @@ PROCESS
 		# Build FQDN using hostname and domain strings.
 		$fqdn = $hostname + "." + $MachineDomain
 
-		# SPN check is done for PI Coresight using a custom host header.
-		If ( $ServiceName -eq "coresight_custom" ) 
+		# SPN check is done for PI Vision using a custom host header.
+		If ( $ServiceName -eq "pivision_custom" ) 
 		{ 
-			# Pass the Coresight AppPool identity as the service account.
-			$svcacc = $csappPool
+			# Pass the AppPool identity as the service account.
+			$svcacc = $AppPool
 			$svcaccParsed = Get-PISysAudit_ParseDomainAndUserFromString -UserString $svcacc -DBGLevel $DBGLevel
 				
 			# Take Custom header information and create its short and long version.
-			If ($CoresightHeader -match "\.") 
+			If ($CustomHeader -match "\.") 
 			{
-				$csCustomHeaderLong = $CoresightHeader
-				$pos = $CoresightHeader.IndexOf(".")
-				$csCustomHeaderShort = $CoresightHeader.Substring(0, $pos)
+				$CustomHeaderLong = $CustomHeader
+				$pos = $CustomHeader.IndexOf(".")
+				$CustomHeaderShort = $CustomHeader.Substring(0, $pos)
 			} 
 			Else 
 			{ 
-				$csCustomHeaderShort = $CoresightHeader
-				$csCustomHeaderLong = $CoresightHeader + "." + $MachineDomain
+				$CustomHeaderShort = $CustomHeader
+				$CustomHeaderLong = $CustomHeader + "." + $MachineDomain
 			}
 
 			# Deal with the custom header - run nslookup and capture the result.
-			$AliasTypeCheck = Get-PISysAudit_ResolveDnsName -LookupName $CoresightHeader -Attribute Type -DBGLevel $DBGLevel
+			$AliasTypeCheck = Get-PISysAudit_ResolveDnsName -LookupName $CustomHeader -Attribute Type -DBGLevel $DBGLevel
 
 			# Check if the custom header is a Alias (CNAME) or Host (A) entry.
 			If ($AliasTypeCheck -eq 'CNAME') 
@@ -3646,23 +3650,23 @@ PROCESS
 			
 				$hostnameSPN = $($serviceType.ToLower() + "/" + $hostname.ToLower())
 				$fqdnSPN = $($serviceType.ToLower() + "/" + $fqdn.ToLower())
-				$csCustomHeaderSPN = $($serviceType.ToLower() + "/" + $csCustomHeaderShort.ToLower())
-				$csCustomHeaderLongSPN = $($serviceType.ToLower() + "/" + $csCustomHeaderLong.ToLower())
+				$CustomHeaderSPN = $($serviceType.ToLower() + "/" + $CustomHeaderShort.ToLower())
+				$CustomHeaderLongSPN = $($serviceType.ToLower() + "/" + $CustomHeaderLong.ToLower())
 			
 				$result = Test-PISysAudit_ServicePrincipalName -HostName $hostname -MachineDomain $MachineDomain `
 																-SPNShort $hostnameSPN -SPNLong $fqdnSPN `
-																-SPNShortAlias $csCustomHeaderSPN -SPNLongAlias $csCustomHeaderLongSPN `
+																-SPNShortAlias $CustomHeaderSPN -SPNLongAlias $CustomHeaderLongSPN `
 																-TargetAccountName $svcaccParsed.UserName -ServiceAccountDomain $svcaccParsed.Domain -DBGLevel $DBGLevel
 						
 				return $result			
 			} 			
 			ElseIf($AliasTypeCheck -eq 'A')
 			{ 
-				$csCustomHeaderSPN = $($serviceType.ToLower() + "/" + $csCustomHeaderShort.ToLower())
-				$csCustomHeaderLongSPN = $($serviceType.ToLower() + "/" + $csCustomHeaderLong.ToLower())
+				$CustomHeaderSPN = $($serviceType.ToLower() + "/" + $CustomHeaderShort.ToLower())
+				$CustomHeaderLongSPN = $($serviceType.ToLower() + "/" + $CustomHeaderLong.ToLower())
 
 				$result = Test-PISysAudit_ServicePrincipalName -HostName $hostname -MachineDomain $MachineDomain `
-																-SPNShort $csCustomHeaderSPN -SPNLong $csCustomHeaderLongSPN `
+																-SPNShort $CustomHeaderSPN -SPNLong $CustomHeaderLongSPN `
 																-TargetAccountName $svcaccParsed.UserName -TargetDomain $svcaccParsed.Domain -DBGLevel $DBGLevel
 
 				return $result
@@ -3675,16 +3679,16 @@ PROCESS
 				return $null
 			}
 		}	
-		# SPN Check is done for PI Coresight or other service
+		# SPN Check is done for PI Vision or other service
 		Else
 		{
-			# SPN check is done for PI Coresight without custom headers.
-			If ( $ServiceName -eq "coresight" )
+			# SPN check is done for PI Vision without custom headers.
+			If ( $ServiceName -eq "pivision" )
 			{
-				# In case of PI Coresight, the AppPool account is used in the SPN check.
-				$svcacc = $csappPool
+				# AppPool account is used in the SPN check.
+				$svcacc = $AppPool
 			}
-			# SPN check is not done for PI Coresight.
+			# SPN check is not done for PI Vision.
 			Else
 			{
 				# Get the Service account
@@ -3692,7 +3696,7 @@ PROCESS
 			}
 			$svcaccParsed = Get-PISysAudit_ParseDomainAndUserFromString -UserString $svcacc -DBGLevel $DBGLevel
 
-			# Proceed with checking SPN for Coresight or non-IIS app (PI/AF).
+			# Proceed with checking SPN for PI Vision or non-IIS app (PI/AF).
 			# Distinguish between Domain/Virtual account and Machine Accounts.
 			$hostnameSPN = $($serviceType.ToLower() + "/" + $hostname.ToLower())
 			$fqdnSPN = $($serviceType.ToLower() + "/" + $fqdn.ToLower())
@@ -4509,7 +4513,8 @@ param(
 					"PIAFServer", "AFServer", "PIAF", "AF",
 					"SQLServer", "SQL", "PICoresightServer", 
 					"CoresightServer", "PICoresight", 
-					"Coresight", "PICS", "CS")]
+					"Coresight", "PICS", "CS", "PIVision",
+					"PIVisionServer","Vision","VisionServer","PV")]
 		[alias("type")]
 		[string]		
 		$PISystemComponentType,
@@ -4676,13 +4681,19 @@ PROCESS
 		($PISystemComponentType.ToLower() -eq "coresightserver") -or `
 		($PISystemComponentType.ToLower() -eq "coresight") -or `
 		($PISystemComponentType.ToLower() -eq "cs") -or `
-		($PISystemComponentType.ToLower() -eq "pics"))
+		($PISystemComponentType.ToLower() -eq "pics") -or `
+		($PISystemComponentType.ToLower() -eq "pivision") -or `
+		($PISystemComponentType.ToLower() -eq "visionserver") -or `
+		($PISystemComponentType.ToLower() -eq "vision") -or `
+		($PISystemComponentType.ToLower() -eq "pivisionserver") -or `
+		($PISystemComponentType.ToLower() -eq "pv")
+	)
 	{
 		# Set the properties.
 		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
 		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer		
-		# Use normalized type description as 'PICoresightServer'
-		$AuditRoleType = "PICoresightServer"
+		# Use normalized type description as 'PIVisionServer'
+		$AuditRoleType = "PIVisionServer"
 		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $AuditRoleType
 		# Nullify all of the MS SQL specific values
 		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $null
@@ -5238,8 +5249,8 @@ PROCESS
 				{ StartPIAFServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel }
 				elseif($role.AuditRoleType -eq "SQLServer")
 				{ StartSQLServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel }
-				elseif($role.AuditRoleType -eq "PICoresightServer")
-				{ StartPICoresightServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel}
+				elseif($role.AuditRoleType -eq "PIVisionServer")
+				{ StartPIVisionServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel}
 
 				$currCheck++
 			}

--- a/PISecurityAudit/Scripts/UpdateValidationsInHelp.ps1
+++ b/PISecurityAudit/Scripts/UpdateValidationsInHelp.ps1
@@ -19,12 +19,7 @@
 # ************************************************************************
 
 # Reload the module to make sure you are using the latest
-if($PSVersionTable.PSVersion.Major -eq 2){$PSVersion2 = $true}
-else{$PSVersion2 = $false}
-
-if($PSVersion2){$UpdateScriptRoot = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition}
-else {$UpdateScriptRoot = $PSScriptRoot}
-$rootModuleDir = Split-Path $UpdateScriptRoot
+$rootModuleDir = Split-Path $PSScriptRoot
 
 if(Get-Module pisysaudit){remove-module pisysaudit}
 $modulepath = $rootModuleDir + '\PISYSAUDIT.psd1'
@@ -60,7 +55,7 @@ foreach ($line in $helpFile)
             foreach ($lib in $libs)
             {
 				$fnsSorted = @()
-                foreach($fn in $lib.Keys){ $fnsSorted += Get-Help $fn }
+                foreach($fn in $lib.Name){ $fnsSorted += Get-Help $fn }
                 # Keys get out of order so we need to sort them by ID (Synopsis is of form <ID> - <Name>)
 				$fnsSorted = $fnsSorted | Select-Object * | Sort-Object Synopsis
 				# now we can record each validation.

--- a/PISecurityAudit/en-US/about_PISYSAUDIT.help.txt
+++ b/PISecurityAudit/en-US/about_PISYSAUDIT.help.txt
@@ -113,7 +113,7 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		For more on the advantages of Windows Server Core, please see:
 		https://msdn.microsoft.com/en-us/library/hh846314(v=vs.85).aspx 
 
-		AU10003 - Firewall Enabled
+		AU10003 - Windows Firewall Enabled
 		VALIDATION: verifies that the Windows host based firewall is enabled. 
 		COMPLIANCE: enable the Windows firewall for Domain, Private and Public Scope.  
 		A firewall's effectiveness is heavily dependent on the configuration.  
@@ -139,25 +139,50 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		For more information on specific UAC features, see: 
 		https://technet.microsoft.com/en-us/library/dd835564(v=ws.10).aspx 
 
+		AU10006 - Monitored by OSIsoft NOC
+		VALIDATION: Checks if PI Diagnostics and PI Agent are installed and enabled. 
+		COMPLIANCE: Ensure that PI Agent and PI Diagnostics are installed and running
+			on the machine so that the OSIsoft NOC will detect issues. 
+
+		AU10007 - Internet Explorer Enhanced Security
+		VERIFICATION: Validates that IE Enhanced Security is enabled 
+		COMPLIANCE: Ensure that Internet Explorer Enhanced Security is enabled
+			for both Administrators and Users. More information is available at: 
+			 https://technet.microsoft.com/en-us/library/dd883248(v=ws.10).aspx  
+
+		AU10008 - Software Updates
+		VERIFICATION: Validates that the operating system and Microsoft applications 
+			receive updates 
+		COMPLIANCE: Ensure that the operating system and the Microsoft applications
+			have been updated in the last 60 days.
+			https://support.microsoft.com/en-us/help/311047/how-to-keep-your-windows-computer-up-to-date 
+
+		AU10009 - No Internet Access
+		VERIFICATION: Checks that this server is not able to access the internet. 
+		COMPLIANCE: Implement firewall restrictions to prevent access to the internet 
+			from the server.
+
 		AU20001 - PI Data Archive Table Security Check
 		VALIDATION: examines the database security of the PI Data Archive and flags any 
 		ACLs that contain access for PIWorld as weak. 
 		COMPLIANCE: remove PIWorld access from all database security ACLs.  Note that prior
 		removing PIWorld access, you need to evaluate which applications are relying on that 
-		access so that you can grant those applications access explicitly.
+		access so that you can grant those applications access explicitly.  This check will
+		also pass if PIWorld is disabled globally.
 
 		AU20002 - PI Admin Usage Check
 		VALIDATION: verifies that the piadmin PI User is not used in mappings or trusts.
 		COMPLIANCE: replace any trusts or mappings that use piadmin with a mapping or trust to a
 		PI Identity with appropriate privilege for the applications that will use it.  Will also
-		check if trusts with piadmin have been disabled globally.  This can be done by checking 
-		"User cannot be used in a Trust" in the Properties menu for the piadmin PI User.  To 
-		access this menu open use the Idenitities, Users, & Groups plugin in PI SMT, navigate to 
-		the PI User tab, right click the piadmin entry and select Properties in the context menu.  
+		check if trusts and mappings to piadmin have been disabled globally.  This can be done by  
+		checking "User cannot be used in a Trust" and "User cannot be used in a Mapping" in the 
+		Properties menu for the piadmin PI User.  To access this menu open use the Identities, 
+		Users, & Groups plugin in PI SMT, navigate to the PI User tab, right click the piadmin 
+		entry and select Properties in the context menu.  
 		For more information, see "Security Best Practice" #4 in KB00833: 
 		https://techsupport.osisoft.com/Troubleshooting/KB/KB00833 
 
-		AU20003 - PI Data Archive Subsystem Version Check
+		AU20003 - PI Data Archive Version
 		VALIDATION: verifies that the PI Data Archive is using the most recent release.   
 		COMPLIANCE: upgrade the PI Data Archive to the latest version, PI Data Archive 
 		2016 R2 (3.4.405.1198).  For more information, see the "Upgrade a PI Data Archive Server" 
@@ -201,6 +226,31 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		Authentication possible.  For more information, see "PI and Kerberos authentication" in 
 		the PI Live Library. 
 		https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-531FFEC4-9BBB-4CA0-9CE7-7434B21EA06D 
+
+		AU20009 - PI Collective
+		VALIDATION: Checks if the PI Data Archive is a member of a High Availability Collective. 
+		COMPLIANCE: Ensure that the PI Data Archive is a member of a PI Collective to allow for 
+			High Availability. 
+
+		AU20010 - No Client Software
+		VALIDATION: Checks if common client software is installed on the PI Data Archive machine. 
+		COMPLIANCE: Ensure the PI Processbookt and Microsoft Office are not installed
+			on the PI Data Archive machine, as these programs should be used on client
+			machines only. 
+
+		AU20011 - PI Firewall Used
+		VALIDATION: Checks that PI Firewall is used. 
+		COMPLIANCE: The default PI Firewall rule of "Allow *.*.*.*" should 
+			be removed and replaced with specific IPs or subnets that may 
+			connect to the PI Data Archive. For more information on PI Firewall,
+			see https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v8/GUID-14FC1696-D64B-49B0-96ED-6EEF3CE92DCB  
+
+		AU20013 - PI Backup Configured
+		VALIDATION: Ensures that PI Backups are configured and current. 
+		COMPLIANCE: Configure PI Backup to back up PI Data Archive configuration
+			and data daily. It is best practice to back up to a local disk on the 
+			PI Data Archive machine, then copy the backup to an off-machine location. 
+			For more information, see https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v8/GUID-8F56FDA9-505C-4868-8483-E51435E80A61
 
 		AU30001 - PI AF Server Service Account Check
 		VALIDATION: verifies that the AF Server application service is not running as the account 
@@ -262,6 +312,23 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		For more information, see "PI AF Access rights" in the PI Live Library. 
 		https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-23016CF4-6CF1-4904-AAEC-418EEB00B399
 
+		AU30009 - AF Connection to SQL
+		VERIFICATION: AF Service connects to the SQL Server with Windows authentication. 
+		COMPLIANCE: Ensure that the AF Application service connects to the SQL Server with
+			Windows Authentication. Windows Authentication is the preferred method, see:
+			https://msdn.microsoft.com/en-us/library/ms144284.aspx
+
+		AU30010 - Restrict AF World Identity
+		VERIFICATION: Ensures that the World Identity has been disabled or restricted 
+		COMPLIANCE: For best practice, disable the World Identity on the AF Server. 
+			Alternatively, remove the mapping to the \Everyone group and re-map it to 
+			an appropriate group with only users who need access to PI AF.
+
+		AU30011 - Restrict Write Access
+		VERIFICATION: Write access to objects should be limited to power users. 
+		COMPLIANCE: Database level write access should not be granted to any well-known, 
+			end user groups. Similarly, write access to analyses should be limited. 
+
 		AU40001 - SQL Server xp_CmdShell Check
 		VALIDATION: verifies that SQL Server does not have xp_CmdShell enabled.
 		COMPLIANCE: disable xp_CmdShell configuration option.  This option can be configured 
@@ -290,18 +357,11 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		more information, see:
 		https://msdn.microsoft.com/en-us/library/ms191188.aspx
 
-		AU40005 - SQL Server CLR Configuration Option Check
-		VALIDATION: verifies that SQL Server does not have CLR enabled. 
-		COMPLIANCE: disable the CLR option.  This option can be configured using 
-		the Policy-Based Management or the sp_configure stored procedure. For 
-		more information, see:
-		https://msdn.microsoft.com/en-us/library/ms191188.aspx
-
-		AU40006 - SQL Server Cross DB Ownership Chaining Option Check
-		VALIDATION: verifies that SQL Server does not have Cross DB Ownership 
-		Chaining enabled. 
-		COMPLIANCE: disable the Cross DB Ownership Chaining option.  This option 
-		can be configured using the Policy-Based Management or the sp_configure 
+		AU40008 - SQL Server sa Login Check
+		VALIDATION: verifies that SQL Server does not have the sa login enabled 
+		enabled. 
+		COMPLIANCE: disable the sa login.  This option can 
+		be configured using the Policy-Based Management or the sp_configure 
 		stored procedure. For more information, see:
 		https://msdn.microsoft.com/en-us/library/ms191188.aspx
 
@@ -313,35 +373,42 @@ VALIDATION CHECKS AND COMPLIANCE CONDITIONS
 		stored procedure. For more information, see:
 		https://msdn.microsoft.com/en-us/library/ms191188.aspx
 
-		AU40008 - SQL Server sa Login Check
-		VALIDATION: verifies that SQL Server does not have the sa login enabled 
-		enabled. 
-		COMPLIANCE: disable the sa login.  This option can 
-		be configured using the Policy-Based Management or the sp_configure 
+		AU40006 - SQL Server Cross DB Ownership Chaining Option Check
+		VALIDATION: verifies that SQL Server does not have Cross DB Ownership 
+		Chaining enabled. 
+		COMPLIANCE: disable the Cross DB Ownership Chaining option.  This option 
+		can be configured using the Policy-Based Management or the sp_configure 
 		stored procedure. For more information, see:
 		https://msdn.microsoft.com/en-us/library/ms191188.aspx
 
-		AU50001 - Check for latest version of Coresight
-		VALIDATION: verifies PI Coresight version.
-		COMPLIANCE: upgrade to the latest version of PI Coresight.  For more information, 
+		AU40005 - SQL Server CLR Configuration Option Check
+		VALIDATION: verifies that SQL Server does not have CLR enabled. 
+		COMPLIANCE: disable the CLR option.  This option can be configured using 
+		the Policy-Based Management or the sp_configure stored procedure. For 
+		more information, see:
+		https://msdn.microsoft.com/en-us/library/ms191188.aspx
+
+		AU50001 - Check for latest version of PI Vision
+		VALIDATION: verifies PI Vision version.
+		COMPLIANCE: upgrade to the latest version of PI Vision.  For more information, 
 		see "Upgrade a PI Coresight installation" in the PI Live Library.
 		https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6
 
-		AU50002 - Check Coresight AppPools identity
-		VALIDATION: checks PI Coresight AppPool identity.
+		AU50002 - Check PI Vision AppPools identity
+		VALIDATION: checks PI Vision AppPool identity.
 		COMPLIANCE: Use a custom domain account. Network Service is acceptable, but not ideal. 
 		For more information, see "Create a service account for PI Coresight" in the PI Live Library. 
 		https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-A790D013-BAC8-405B-A017-33E55595B411
 
-		AU50003 - Coresight SSL check
-		VALIDATION: Checks whether SSL is enabled and enforced on the Coresight Web Site.
+		AU50003 - PI Vision SSL check
+		VALIDATION: Checks whether SSL is enabled and enforced on the PI Vision Web Site.
 		COMPLIANCE: A valid HTTPS binding is configured and only connections with SSL are allowed. The SSL certificate is issued by a Certificate Authority.
 		For more information, see "Configure Secure Sockets Layer (SSL) access" in the PI Live Library. 
 		https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-CB46B733-264B-48D3-9033-73D16B4DBD3B
 
-		AU50004 - Coresight SPN check
-		VALIDATION: Checks PI Coresight SPN assignment. 
-		COMPLIANCE: HTTP or HOST SPNs exist and are assigned to the Coresight AppPool account. This makes Kerberos Authentication possible.
+		AU50004 - PI Vision SPN check
+		VALIDATION: Checks PI Vision SPN assignment. 
+		COMPLIANCE: HTTP or HOST SPNs exist and are assigned to the PI Vision AppPool account. This makes Kerberos Authentication possible.
 		For more information, see the PI Live Library link below. 
 		https://livelibrary.osisoft.com/LiveLibrary/content/en/coresight-v7/GUID-68329569-D75C-406D-AE2D-9ED512E74D46
 
@@ -363,4 +430,6 @@ CONTRIBUTE
 	If you encounter a bug, please submit it as an issue on the GitHub repo
 	or fix the bug and submit a pull request!
         https://github.com/osisoft/PI-System-Audit-Tools/issues
+
+
 


### PR DESCRIPTION
Changed all instances from PI Coresight, Coresight to PI Vision, PIVision, except where the coresight name is necessary for "legacy" support.

Updated examples to use PI Vision name.

Refreshed conceptual help to reflect synopsis changes.  (Fixed issue where library functions were treated as entries in a hashtable rather than the custom object)

Fixes #224 