### PR TITLE
Improve reliability of AFDiag invocation.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3494,7 +3494,7 @@ PROCESS
 	try
 	{
 		# Get the AF Server installation path to locate the service executable and afdiag.
-		$PIHome_AF_path = Get-PISysAudit_RegistryKeyValue "HKLM:\SOFTWARE\PISystem\AF Server" "CurrentInstallationPath" -lc $LocalComputer -rc $RemoteComputerName -DBGLevel $DBGLevel
+		$PIHome_AF_path = Get-PISysAudit_RegistryKeyValue "HKLM:\SOFTWARE\PISystem\AF Server" "CurrentInstallationPath" -lc $LocalComputer -rcn $RemoteComputerName -DBGLevel $DBGLevel
 		# Set the path to reach out the afdiag.exe CLU.
 		$AFDiagExec = PathConcat -ParentPath $PIHome_AF_path -ChildPath "afdiag.exe"
 		# Set the path to reach out the AFService executable.

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3493,13 +3493,8 @@ PROCESS
 	
 	try
 	{
-		#......................................................................................
-		# Set Paths
-		#......................................................................................
-		# Set the PIPC folder (64 bit).		
-		$PIHome64_path = Get-PISysAudit_EnvVariable "PIHOME64" -lc $LocalComputer -rcn $RemoteComputerName
-		# Set the PIPC\AF folder (64 bit).		
-		$PIHome_AF_path = PathConcat -ParentPath $PIHome64_path -ChildPath "AF"
+		# Get the AF Server installation path to locate the service executable and afdiag.
+		$PIHome_AF_path = Get-PISysAudit_RegistryKeyValue "HKLM:\SOFTWARE\PISystem\AF Server" "CurrentInstallationPath" -lc $LocalComputer -rc $RemoteComputerName -DBGLevel $DBGLevel
 		# Set the path to reach out the afdiag.exe CLU.
 		$AFDiagExec = PathConcat -ParentPath $PIHome_AF_path -ChildPath "afdiag.exe"
 		# Set the path to reach out the AFService executable.


### PR DESCRIPTION
Use the installation path key for the AF Server to find the service executable and afdiag utility.

Closes #210