### PR TITLE
Enhanced connection statistics in export utility

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3771,7 +3771,12 @@ PROCESS
 		{
 			$SecureStatus = "Unknown"
 			$SecureStatusDetail = "Connection not found."
-			if($PIConnection.AuthenticationProtocol -ne 'Windows') # Only Windows Connections can use transport security
+			if($PIConnection.AuthenticationProtocol -eq 'Subsystem')
+			{
+				$SecureStatus = "Secure" 
+				$SecureStatusDetail = "Subsystem"
+			}
+			elseif($PIConnection.AuthenticationProtocol -ne 'Windows') # Only Windows Connections can use transport security
 			{ 
 				$SecureStatus = "Not Secure"
 				$SecureStatusDetail = "Insecure protocol ({0})" -f $PIConnection.AuthenticationProtocol


### PR DESCRIPTION
Export-PISecConfig now leverages the processed network manager stats with connection security attributes.  This command also includes the DataItem parameter to specify a specific data item to retrieve if not all are desired.

Exported connections with security attributes allows for easy identification of insecure connections.

Closes #106 