### PR TITLE
Fix issue where aliases are seen as remote machines.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
@@ -936,7 +936,7 @@ PROCESS
 		$testAddress = '8.8.8.8'
 		$scriptBlock = {
 				param([string]$Address)
-				Test-Connection -ComputerName $Address -Count 4 -Quiet # Quiet simply returns true or false
+				Test-Connection -ComputerName $Address -Count 4 -Quiet -ErrorAction SilentlyContinue # Quiet simply returns true or false
 		}
 
 		if($LocalComputer)

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -799,25 +799,15 @@ param(
 		if($ComputerParams.IsLocal)
 		{
 			$result = $true
-			$msgTemplate = "The server: {0} does not need WinRM communication because it will use a local connection"
-			$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
+			$msg = "The server: {0} does not need WinRM communication because it will use a local connection" -f $ComputerParams.ComputerName
 			Write-PISysAudit_LogMessage $msg "Debug" $fn -dbgl $DBGLevel -rdbgl 1					
 		}
 		else
 		{								
 			$result = Test-WSMan -authentication default -ComputerName $ComputerParams.ComputerName -ErrorAction SilentlyContinue
-			if($null -eq $result)
-			{
-				$msgTemplate = "The server: {0} has a problem with WinRM communication"
-				$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
-				Write-PISysAudit_LogMessage $msg "Error" $fn
-				New-PISysAuditError -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName `
-									-at $AuditTable -an 'Computer' -fn $fn -msg $msg
-			}
 		}
 		
-		if($result) { return $true }
-		else { return $false }
+		return $result
 	}
 	catch
 	{
@@ -2676,7 +2666,7 @@ param(
 		$LookupName,
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]
 		[alias("at")]
-		[ValidateSet('Type')]
+		[ValidateSet('Type', 'HostName', 'FQDN')]
 		[string]
 		$Attribute='Type',
 		[alias("dbgl")]
@@ -2696,14 +2686,24 @@ PROCESS
 			if($recordObjectType -eq 'Object[]') # Either CNAME and corresponding A records or collection of A and AAAA records
 			{
 				if($record[0].GetType().Name -eq 'DnsRecord_PTR')
-				{ $type = $record[0].Type }
+				{ 
+					$type = $record[0].Type 
+					$name = $record[0].NameHost
+				}
 				else 
-				{ $type = 'A' } 
+				{ 
+					$type = 'A'
+					$name = $record[0].Name
+				} 
 			}
-			elseif($recordObjectType -in @('DnsRecord_A','DnsRecord_AAAA'))
-			{ $type = 'A' }
 			else
-			{ $type = $record.Type }
+			{
+				if($recordObjectType -in @('DnsRecord_A','DnsRecord_AAAA'))
+				{ $type = 'A' } 
+				else
+				{ $type = $record.Type }
+				$name = $record.Name
+			}
 		}
 		else
 		{
@@ -2719,14 +2719,33 @@ PROCESS
 			}
 			else
 			{
-				if($null -eq $($record -match 'Aliases:')) # A or AAAA
+				if($null -eq $($record -match 'Aliases:')) # Host entry
 				{ $type = 'A'	}
-				else # CNAME
+				else # Alias
 				{ $type = 'CNAME' }
+				foreach ($line in $record)
+                {
+                    if($line -match 'Name:')
+                    { 
+						$name = $line.ToString().Split(':')[1].Trim() 
+						break
+					}
+                }
 			}
 		}
 
-		return $type
+		switch ($Attribute) {
+			'Type' {$returnvalue = $type}
+			'HostName' {
+							if($name.IndexOf('.') -ne -1)
+							{ $returnvalue = $name.Split('.')[0] }
+							else
+							{ $returnvalue = $name }
+						}
+			'FQDN' {$returnvalue = $name}
+		}
+
+		return $returnvalue
 	}
 	catch
 	{
@@ -5255,7 +5274,34 @@ PROCESS
 	foreach($item in $ComputerParamsTable.GetEnumerator())
 	{
 		# Run no checks if WSMan is not available
-		if((ValidateWSMan -cp $item -at $auditHashTable -dbgl $DBGLevel) -EQ $true)
+		$wsManValidated = ValidateWSMan -cp $item -at $auditHashTable -dbgl $DBGLevel
+		
+		# If WSman fails we can check if IsLocal is set properly. 
+		# This check is too expensive to check frivolously, so we only check on failure.
+		if(-not($wsManValidated))
+		{
+			$computerRole = $item.Value[0]
+			$resolvedName = Get-PISysAudit_ResolveDnsName -LookupName $computerRole.ComputerName -Attribute HostName -DBGLevel $DBGLevel
+			$localComputerName = Get-Content Env:\COMPUTERNAME
+			if($resolvedName.ToLower() -eq $localComputerName.ToLower())
+			{ 
+				foreach($role in $item.Value)
+				{ $role.IsLocal = $true } 
+				$wsManValidated = $true
+
+				$msg = "The server: {0} does not need WinRM communication because it will use a local connection (alias used)" -f $role.ComputerName
+				Write-PISysAudit_LogMessage $msg "Debug" $fn -dbgl $DBGLevel -rdbgl 1
+			}
+			else
+			{
+				$msg = "The server: {0} has a problem with WinRM communication" -f $computerRole.ComputerName
+				Write-PISysAudit_LogMessage $msg "Error" $fn
+				New-PISysAuditError -lc $computerRole.IsLocal -rcn $computerRole.ComputerName `
+										-at $auditHashTable -an 'Computer' -fn $fn -msg $msg
+			}
+		}
+
+		if($wsManValidated)
 		{
 			foreach($role in $item.Value)
 			{
@@ -5284,6 +5330,7 @@ PROCESS
 			# Skip progress bar ahead for these ckecks since WSman failed
 			$currCheck += $item.Value.Count
 		}
+
 	}
 	Write-Progress -Activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -PercentComplete 100 
 	Write-Progress -Activity $ActivityMsg -Status $statusMsgCompleted -Id 1 -Completed


### PR DESCRIPTION
When Test-WSMan fails, it now checks to see if the name used resolves to the local computer.  The reason for not resolving the name with the initial setting of IsLocal is that the Resolve-DnsName and nslookup calls negatively impact performance.  I didn't want to hurt performance for all successful setups just to handle the edge case.  

Also silenced the error on test-connection when the connection fails since in this case, failure is what we want and we can conclude the result from a false return value.  Bubbling the error up will likely confuse users. 

Fixes #222 