### PR TITLE
Oops! Encoding broken on zips.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.txt eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/PISecurityAudit/Readme.txt
+++ b/PISecurityAudit/Readme.txt
@@ -2,7 +2,7 @@
 # Requirements #
 ################
 
-PowerShell version 3.0 or later is required.
+PowerShell version 3.0 or later is required to run this tool.
 If targeting a remote machine with the scripts then PS-Remoting must be enabled on the target machine.  You can test whether or not PS-Remoting is enabled with the command below, where <TargetComputer> is the machine that the scripts will be run against.  We do not recommend enabling PS-Remoting to run this tool if it is not already enabled.
 	Test-WSMan -authentication default -ComputerName <TargetComputer>
 
@@ -13,7 +13,7 @@ OSIsoft.PowerShell: PowerShell Tools for the PI System are required for the PI D
 Permissions:
 PI Data Archive - Read access to PIDBSEC, PIMAPPING, PITRUST, PIUSER and PITUNING in database security.
 PI AF Server - Process must be run as administrator to access AFDiag locally.
-PI Coresight - Process must be run as administrator to access IIS Configuration data.
+PI Vision - Process must be run as administrator to access IIS Configuration data.
 SQL Server - Login with the public server role.
 
 #############################


### PR DESCRIPTION
Wanted to squeeze this in before we have people testing.  As this [Stack Overflow thread](https://stackoverflow.com/questions/17347611/downloading-a-zip-from-github-removes-newlines-from-text-files) points out, downloading the zip changes the newlines to a format Windows doesn't understand unless you override it in .gitattributes.