### PR TITLE
Report opener and clarifications per user feedback

### DIFF
--- a/PISecurityAudit/Readme.txt
+++ b/PISecurityAudit/Readme.txt
@@ -7,14 +7,21 @@ If targeting a remote machine with the scripts then PS-Remoting must be enabled 
 	Test-WSMan -authentication default -ComputerName <TargetComputer>
 
 Modules: 
-WebAdministration Module: the IIS Management PowerShell module must be installed on the target web server to read IIS configuration data when performing a PI Vision role audit.
-OSIsoft.PowerShell: PowerShell Tools for the PI System are required for the PI Data Archive and PI AF Server checks.
+The following role audit checks have specific module requirements below.
+PI Vision: 
++WebAdministration (IIS Management) - must be installed on the target web server to read IIS configuration data when performing a PI Vision role audit.
+PI AF Server: 
++OSIsoft.PowerShell (PowerShell Tools for the PI System) - must be installed on machine running the PI Security Audit Tools script
+PI Data Archive: 
++OSIsoft.PowerShell (PowerShell Tools for the PI System) - must be installed on machine running the PI Security Audit Tools script
+SQL Server: 
++SQLPS - must be installed on machine running the PI Security Audit Tools script.  To install the SQLPS module with minimal other components on Windows 8/Server 2012 or later, go to https://www.microsoft.com/en-us/download/details.aspx?id=52676 and select ENU\x64\PowerShellTools.msi, ENU\x64\SharedManagementObjects.msi and ENU\x64\SQLSysClrTypes.msi.
 
 Permissions:
-PI Data Archive - Read access to PIDBSEC, PIMAPPING, PITRUST, PIUSER and PITUNING in database security.
+PI Data Archive - Read access to PIDBSEC, PIMAPPING, PIMSGSS, PITRUST, PIUSER and PITUNING in database security.
 PI AF Server - Process must be run as administrator to access AFDiag locally.
 PI Vision - Process must be run as administrator to access IIS Configuration data.
-SQL Server - Login with the public server role.
+SQL Server - The user executing the scripts must have a Login with the public server role.
 
 #############################
 # Preparing to run the tool #

--- a/PISecurityAudit/Readme.txt
+++ b/PISecurityAudit/Readme.txt
@@ -72,6 +72,9 @@ Finally, when you are done adding components, launch the audit with the piaudit 
 
 Open the generated *.html file from the Export folder in your favorite browser and examine the results.  
 
+To run all checks, including potentially time consuming checks like connection auditing, increase the AuditLevel (alias: lvl).  Currently supported options are Basic and Verbose.
+	piaudit -cpt $cpt -lvl Verbose
+
 #############################
 # Running a batch of audits #
 #############################

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
@@ -1376,9 +1376,10 @@ PROCESS
 		$version = $global:PIDataArchiveConfiguration.Connection.ServerVersion
 		if($version.Major -ge 3 -and $version.Minor -ge 4 -and $version.Build -ge 395)
 		{
-			$processedPIConnectionStats = $global:PIDataArchiveConfiguration.ConnectionStatistics
+			$processedPIConnectionStats = @()
+			$processedPIConnectionStats += $global:PIDataArchiveConfiguration.ConnectionStatistics
 
-			if($null -ne $processedPIConnectionStats)
+			if($null -ne $processedPIConnectionStats -and $processedPIConnectionStats.Count -ne 0)
 			{
 				$countSecured = $processedPIConnectionStats.SecureStatus | Where-Object { $_ -eq 'Secure' } | Measure-Object | Select-object -ExpandProperty count	
 				if($countSecured -eq $processedPIConnectionStats.Count)	

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -5352,6 +5352,21 @@ PROCESS
 	Write-PISysAudit_LogMessage $msg "Info" $fn -sc $true
 	$msg = "----- Audit Completed -----"
 	Write-PISysAudit_LogMessage $msg "Info" $fn 
+	
+	$InstallationType = Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows NT\CurrentVersion" -Name "InstallationType" | Select-Object -ExpandProperty "InstallationType" | Out-String
+	if($ExecutionContext.SessionState.LanguageMode -ne 'ConstrainedLanguage' -and $InstallationType -ne 'Server Core')
+	{
+		$title = "PI Security Audit Report"
+		$message = "Would you like to view the PI Security Audit Report now?"
+		$yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes","Open the report in your default browser."
+		$no = New-Object System.Management.Automation.Host.ChoiceDescription "&No","View the report later."
+		$options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
+
+		$result = $host.ui.PromptForChoice($title, $message, $options, 0) 
+		if($result -eq 0)
+		{ Start-Process -FilePath $(PathConcat $exportPath -ChildPath $reportName) }
+	}
+
 }
 
 END {}


### PR DESCRIPTION
Per user feedback:
-Clarified requirements in the readme file
-Added a 'report opener upper' to prompt to open report for them so that they won't miss the report in the output or have to navigate to it manually as an unnecessary step. Note: checks for constrained language mode or server core on the executing system before prompting to avoid attempting when the prompt will be blocked or a browser will be unavailable.