### PR TITLE
Improved reliability of Set function for PIDatabaseSecurity.

### DIFF
--- a/PISecurityAuditDSC/Configuration/PIDataArchive_BasicWindowsImplementation.ps1
+++ b/PISecurityAuditDSC/Configuration/PIDataArchive_BasicWindowsImplementation.ps1
@@ -8,7 +8,6 @@
 
     Node $ComputerName
     {
-        
         # Enumerate Basic WIS Roles
         $BasicWISRoles = @(
                             @{Name='PI Buffers';Description='Identity for PI Buffer Subsystem and PI Buffer Server';},
@@ -75,16 +74,19 @@
             Ensure = "Present"
             PIDataArchive = $ComputerName
         }
-
+        
         # Set PI Database Security Rules
         $DatabaseSecurityRules = @(
                                     @{Name='PIAFLINK';Security='piadmins: A(r,w)'},
                                     @{Name='PIARCADMIN';Security='piadmins: A(r,w)'},
                                     @{Name='PIARCDATA';Security='piadmins: A(r,w)'},
                                     @{Name='PIAUDIT';Security='piadmins: A(r,w)'},
-                                    @{Name='PIBACKUP';Security='piadmins: A(r,w)'},
+                                    @{Name='PIBACKUP';Security='piadmins: A(r,w)'}, 
                                     @{Name='PIBatch';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r)'},
-                                    @{Name='PIBATCHLEGACY';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r)'},
+                                    # PIBACTHLEGACY applies to the old batch subsystem which predates the PI Batch Database.
+                                    # Unless the pibatch service is running, and there is a need to keep it running, this
+                                    # entry can be safely ignored. 
+                                    # @{Name='PIBATCHLEGACY';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r)'},
                                     @{Name='PICampaign';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r)'},
                                     @{Name='PIDBSEC';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r) | PI Web Apps: A(r)'},
                                     @{Name='PIDS';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r) | PI Points&Analysis Creator: A(r,w)'},
@@ -97,7 +99,7 @@
                                     @{Name='PITransferRecords';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r)'},
                                     @{Name='PITRUST';Security='piadmins: A(r,w)'},
                                     @{Name='PITUNING';Security='piadmins: A(r,w)'},
-                                    @{Name='PIUSER';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r) | PI Web Apps: A(r)'} #>
+                                    @{Name='PIUSER';Security='piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r) | PI Web Apps: A(r)'}
                                   )
 
         Foreach($DatabaseSecurityRule in $DatabaseSecurityRules)

--- a/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/CommonResourceHelper.psm1
+++ b/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/CommonResourceHelper.psm1
@@ -15,10 +15,44 @@
         $Ensure = "Present"
         Foreach($Property in $($PIResource | Get-Member -MemberType Property | select -ExpandProperty Name))
         {
-            Write-Verbose "GetResult: $($Property): $($PIResource.$Property)."
+            Write-Verbose "GetResult: $($Property): $($PIResource.$Property.ToString())."
         }
     }
     return $Ensure
 }
 
-Export-ModuleMember -Function @( 'Get-PIResource_Ensure' )
+function Convert-PISecurityStringToHashTable
+{
+    param(
+        [parameter(Mandatory=$true)]
+        [System.String]
+        $SecurityString
+    )
+    [Hashtable]$SecurityTable = @{}
+    # Break pipe delimited ACL into entries
+    # Entry format: <Identity>: A(<Read, Write or 0>)
+    # Example: 'piadmins: A(r,w) | PIWorld: A(r) | PI Users: A(r)'
+    $SecurityEntries = $SecurityString.Split('|').Trim()
+
+    # Construct the desired security hashtable
+    foreach($Entry in $SecurityEntries)
+    {
+        # Split entry into the identity and access
+        $tokens = $Entry.Split(':').Trim()
+        # Assign accordingly
+        $Identity = $tokens[0]
+        $AccessRaw = $tokens[1]
+        # Convert the access to the same format as the current state representation.
+        switch ($AccessRaw)
+        {
+            'A(r,w)' {$Access = 'Read, Write';break}
+            'A(r)' {$Access = 'Read';break}
+            'A(w)' {$Access = 'Write';break}
+            'A()' {$Access = 0;break}
+        }
+        $SecurityTable.Add($Identity,$Access)
+    }
+    return $SecurityTable
+}
+
+Export-ModuleMember -Function @( 'Get-PIResource_Ensure', 'Convert-PISecurityStringToHashTable' )

--- a/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/xPIDatabaseSecurity/xPIDatabaseSecurity.psm1
+++ b/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/xPIDatabaseSecurity/xPIDatabaseSecurity.psm1
@@ -58,7 +58,36 @@ function Set-TargetResource
     }
     else
     { 
-        Set-PIDatabaseSecurity -Connection $Connection -Name $Name -Security $Security 
+        if($Name -eq 'PIBATCHLEGACY')
+        {
+            if($(Get-Service pibatch -ComputerName $PIDataArchive).Status -eq 'Running')
+            {
+                Set-PIDatabaseSecurity -Connection $Connection -Name $Name -Security $Security
+            }
+            else
+            {
+                Write-Verbose "PI Batch Subsystem must be running to edit database security for PIBATCHLEGACY"
+                Write-Verbose "PI Batch Subsystem is no longer needed.  It is recommended to disable the service"
+                Write-Verbose "and ignore the PIBATCHLEGACY database security entry."
+            }
+        }
+        elseif($Name -eq 'AFLINK')
+        {
+            if($(Get-Service piaflink -ComputerName $PIDataArchive).Status -eq 'Running')
+            {
+                Set-PIDatabaseSecurity -Connection $Connection -Name $Name -Security $Security
+            }
+            else
+            {
+                Write-Verbose "PI AF Link Subsystem must be running to edit database security for PIAFLINK"
+                Write-Verbose "If the system does not require MDB synchronization, you can disable the service"
+                Write-Verbose "and ignore teh PIAFLINK database security entry."
+            }
+        }
+        else
+        {
+            Set-PIDatabaseSecurity -Connection $Connection -Name $Name -Security $Security 
+        }
     }
 }
 
@@ -90,8 +119,10 @@ function Test-TargetResource
     if($PIResource.Ensure -eq 'Present')
     {
         if($Ensure -eq 'Present')
-        { 
-            if($PIResource.Security -eq $Security)
+        {
+            Write-Verbose "Testing against value: $Security"
+            $DoACLsMatch = Test-PIDatabaseSecurityACL -DesiredSecurity $Security -CurrentSecurity $PIResource.Security
+            if($DoACLsMatch)
             { 
                 $Result = $true 
             }
@@ -116,10 +147,49 @@ function Test-TargetResource
             $Result = $true 
         }
     }
-    Write-Verbose $Result
+    Write-Verbose "Test result: $Result"
     return $Result
 }
 
+function Test-PIDatabaseSecurityACL
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [parameter(Mandatory=$true)]
+        [System.String]
+        $DesiredSecurity,
+        
+        [parameter(Mandatory=$true)]
+        [System.String]
+        $CurrentSecurity
+    )
+
+    $DesiredSecurityTable = Convert-PISecurityStringToHashTable -SecurityString $DesiredSecurity
+    $CurrentSecurityTable = Convert-PISecurityStringToHashTable -SecurityString $CurrentSecurity
+    if($CurrentSecurityTable.Count -ne $DesiredSecurityTable.Count)
+    {
+        return $false
+    }
+    else
+    {
+        foreach($Entry in $CurrentSecurityTable.GetEnumerator())
+        {
+            if(-not($DesiredSecurityTable.ContainsKey($Entry.Name)))
+            {
+                return $false
+            }
+            else
+            {
+                if($DesiredSecurityTable[$Entry.Name] -ne $Entry.Value)
+                {
+                    return $false
+                }
+            }
+        }
+        return $true
+    }
+}
 
 Export-ModuleMember -Function *-TargetResource
 


### PR DESCRIPTION
Refactored the PIDatabaseSecurity function so that the ACLs are evaluated properly in the comparison and the set function handles special cases for PIAFLINK and PIBATCHLEGACY.  

Created a helper function for ACL conversion to a hashtable.  This can be used to evaluate point or module security as well in the future, should those resources be implemented.