### PR TITLE
Improve reliability of firewall check.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
@@ -348,7 +348,8 @@ PROCESS
 		
 		foreach($profile in $firewallState) 
 		{ 
-			If($profile.Enabled)
+			# Explicitly check if [bool]$true because GPOboolean "False" will give misleading result in PS4
+			If($profile.Enabled -eq $true)
 			{ $validationCounter++ } 
 			Else
 			{ $disabledProfiles += " " + $profile.Name + ";" }

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3172,10 +3172,18 @@ PROCESS
 			}
 			else
 			{
+				# Disabling the Use of Windows Firewall Across Your Network
+				# https://technet.microsoft.com/en-us/library/bb490624.aspx
+				$policyKey = 'HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall'
+				if((Test-Path $policyKey) -eq $false)
+				{
+					$policyKey = 'HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy'
+				}
+
 				# These keys return 0 if disabled, 1 if enabled
-				$domain  = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\DomainProfile | Select-Object -ExpandProperty EnableFirewall
-				$private = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\StandardProfile | Select-Object -ExpandProperty EnableFirewall
-				$public  = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\PublicProfile | Select-Object -ExpandProperty EnableFirewall
+				$domain  = Get-ItemProperty -Path ($policyKey + "\DomainProfile") | Select-Object -ExpandProperty EnableFirewall
+				$private = Get-ItemProperty -Path ($policyKey + "\StandardProfile") | Select-Object -ExpandProperty EnableFirewall
+				$public  = Get-ItemProperty -Path ($policyKey + "\PublicProfile") | Select-Object -ExpandProperty EnableFirewall
 
 				# Assemble and return a list of objects that will mimic the profile objects returned by Get-NetFirewallProfile
 				$firewallState = @()


### PR DESCRIPTION
Properly interpret Firewall settings in PowerShell 4 by explicitly comparing the enabled property to $true.  Before it was treating "False" as a non-zero value, not equal to $false.  Also, added the official MS documented registry key location for windows firewall as the primary target when Get-NetFirewallProfile is not available.

Closes #285 