### PR TITLE
Version checks now reference product page for current release.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB2.psm1
@@ -511,10 +511,15 @@ function Get-PISysAudit_CheckPIServerVersion
 AU20003 - PI Data Archive Version
 .DESCRIPTION
 VALIDATION: Verifies that the PI Data Archive is using the most recent release. <br/>  
-COMPLIANCE: Upgrade the PI Data Archive to the latest version, PI Data Archive 
-2016 R2 (3.4.405.1198).  For more information, see the "Upgrade a PI Data Archive Server" 
-section of the PI Data Archive Installation and Upgrade Guide, Live Library: <br/>
-<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-0BDEB1F5-C72F-4865-91F7-F3D38A2975BD ">https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-0BDEB1F5-C72F-4865-91F7-F3D38A2975BD </a>
+COMPLIANCE: Upgrade the PI Data Archive to the latest version. See the PI Data 
+Archive product page for the latest version and associated documentation:<br/>
+<a href="https://techsupport.osisoft.com/Products/PI-Server/PI-Data-Archive">https://techsupport.osisoft.com/Products/PI-Server/PI-Data-Archive </a><br/>
+For more information on the upgrade procedure, see the "Upgrade a PI Data Archive 
+Server" section of the PI Data Archive Installation and Upgrade Guide, in Live 
+Library: <br/>
+<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v8/GUID-0BDEB1F5-C72F-4865-91F7-F3D38A2975BD ">https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v8/GUID-0BDEB1F5-C72F-4865-91F7-F3D38A2975BD </a><br/>
+Associated security bulletins:<br/>
+<a href="https://techsupport.osisoft.com/Products/PI-Server/PI-Data-Archive/Alerts">https://techsupport.osisoft.com/Products/PI-Server/PI-Data-Archive/Alerts</a>
 #>
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
 param(							
@@ -543,10 +548,9 @@ PROCESS
 	$Severity = "Unknown"
 	try
 	{
-		# Update these for subsequent releases
-		$latestVersion = '3.4.410.1256'
-		$readable = '2017 SP1'
-
+		$latestVersion = '3.4.405.1198'
+		$readable = '2016 R2'
+		
 		$installationVersion = $global:PIDataArchiveConfiguration.Connection.ServerVersion.ToString()
 		$versionInt = [int]($installationVersion -replace '\.', '')
 		$latestInt = [int]($latestVersion -replace '\.', '')
@@ -555,7 +559,8 @@ PROCESS
 		{
 			$result = $false
 			$Severity = 'High'
-			$msg = "Upgrading to PI Data Archive $readable ($latestVersion) is recommended."
+			$msg = "Noncompliant version (" + $installationVersion + ") detected. Upgrading to the latest PI Data Archive version is recommended. "
+			$msg += "See https://techsupport.osisoft.com/Products/PI-Server/PI-Data-Archive for the latest version and associated documentation."
 		}
 		else
 		{

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -622,9 +622,14 @@ function Get-PISysAudit_CheckAFServerVersion
 AU30006 - PI AF Server Version
 .DESCRIPTION
 VALIDATION: Verifies PI AF Server version. <br/>
-COMPLIANCE: Upgrade to the latest version of PI AF Server.  For more information, 
-see "PI AF Server upgrades" in the PI Live Library. <br/>
-<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-CF854B20-29C7-4A5A-A303-922B74CE03C6">https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-CF854B20-29C7-4A5A-A303-922B74CE03C6 </a>
+COMPLIANCE: Upgrade to the latest version of PI AF Server. See the PI AF 
+product page for the latest version and associated documentation:<br/>
+<a href="https://techsupport.osisoft.com/Products/PI-Server/PI-AF">https://techsupport.osisoft.com/Products/PI-Server/PI-AF </a><br/>
+For more information on the upgrade procedure, see "PI AF Server 
+upgrades" in the PI Live Library. <br/>
+<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-CF854B20-29C7-4A5A-A303-922B74CE03C6">https://livelibrary.osisoft.com/LiveLibrary/content/en/server-v7/GUID-CF854B20-29C7-4A5A-A303-922B74CE03C6 </a><br/>
+Associated security bulletins:<br/>
+<a href="https://techsupport.osisoft.com/Products/PI-Server/PI-AF/Alerts">https://techsupport.osisoft.com/Products/PI-Server/PI-AF/Alerts</a>
 #>
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
 param(							
@@ -665,7 +670,7 @@ PROCESS
 				# Form an integer value with all the version tokens.
 				[string]$temp = $InstallVersionTokens[0] + $installVersionTokens[1] + $installVersionTokens[2] + $installVersionTokens[3]
 				$installVersionInt64 = [Convert]::ToInt64($temp)
-				if($installVersionInt64 -gt 2850000)
+				if($installVersionInt64 -gt 2900000)
 				{
 					$result = $true
 					$msg = "Server version is compliant."
@@ -673,8 +678,8 @@ PROCESS
 				else
 				{
 					$result = $false
-					$msg = "Server version is non-compliant: {0}."
-					$msg = [string]::Format($msg, $installVersion)
+					$msg = "Noncompliant version ($installVersion) detected. Upgrading to the latest PI AF version is recommended. "
+					$msg += "See https://techsupport.osisoft.com/Products/PI-Server/PI-AF/ for the latest version and associated documentation."
 				}		
 			}
 			else

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
@@ -194,9 +194,14 @@ function Get-PISysAudit_CheckPIVisionVersion
 AU50001 - PI Vision Version
 .DESCRIPTION
 VALIDATION: Verifies PI Vision version.<br/>
-COMPLIANCE: Upgrade to the latest version of PI Vision.  For more information, 
-see "Upgrade a PI Vision installation" in the PI Live Library.<br/>
-<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/vision-v1/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6">https://livelibrary.osisoft.com/LiveLibrary/content/en/vision-v1/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6</a>
+COMPLIANCE: Upgrade to the latest version of PI Vision. See the PI 
+Vision product page for the latest version and associated documentation:<br/>
+<a href="https://techsupport.osisoft.com/Products/Visualization/PI-Vision/">https://techsupport.osisoft.com/Products/Visualization/PI-Vision/ </a><br/>
+For more information on the upgrade procedure, see "Upgrade a PI Vision 
+installation" in the PI Live Library.<br/>
+<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/vision-v1/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6">https://livelibrary.osisoft.com/LiveLibrary/content/en/vision-v1/GUID-5CF8A863-E056-4B34-BB6B-8D4F039D8DA6</a><br/>
+Associated security bulletins:<br/>
+<a href="https://techsupport.osisoft.com/Products/Visualization/PI-Vision/Alerts">https://techsupport.osisoft.com/Products/Visualization/PI-Vision/Alerts</a>
 #>
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
 param(							
@@ -239,7 +244,8 @@ PROCESS
 		else 
 		{
 			$result = $false
-			$msg = "Version $installVersion is not compliant."
+			$msg = "Noncompliant version ($installVersion) detected. Upgrading to the latest PI Vision version is recommended. "
+			$msg += "See https://techsupport.osisoft.com/Products/Visualization/PI-Vision/ for the latest version and associated documentation."
 		}
 	}
 	catch

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB6.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB6.psm1
@@ -156,9 +156,14 @@ function Get-PISysAudit_CheckPIWebApiVersion
 AU60001 - PI Web API Version
 .DESCRIPTION
 VALIDATION: Verifies PI Web API version.<br/>
-COMPLIANCE: Upgrade to the latest version of PI Web API. For more information,
-see "PI Web API Installation" in the PI Live Library.<br/>
-<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/web-api-v8/GUID-1B8C5B9F-0CD5-4B98-9283-0F5801AB850B">https://livelibrary.osisoft.com/LiveLibrary/content/en/web-api-v8/GUID-1B8C5B9F-0CD5-4B98-9283-0F5801AB850B</a>
+COMPLIANCE: Upgrade to the latest version of PI Web API. See the PI 
+Web API product page for the latest version and associated documentation:<br/>
+<a href="https://techsupport.osisoft.com/Products/Developer-Technologies/PI-Web-API/">https://techsupport.osisoft.com/Products/Developer-Technologies/PI-Web-API/ </a><br/>
+For more information on the upgrade procedure, see "PI Web API Installation" 
+in the PI Live Library.<br/>
+<a href="https://livelibrary.osisoft.com/LiveLibrary/content/en/web-api-v8/GUID-1B8C5B9F-0CD5-4B98-9283-0F5801AB850B">https://livelibrary.osisoft.com/LiveLibrary/content/en/web-api-v8/GUID-1B8C5B9F-0CD5-4B98-9283-0F5801AB850B</a><br/>
+Associated security bulletins:<br/>
+<a href="https://techsupport.osisoft.com/Products/Developer-Technologies/PI-Web-API/Alerts">https://techsupport.osisoft.com/Products/Developer-Technologies/PI-Web-API/Alerts</a>
 #>
 [CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
 param(							
@@ -200,7 +205,8 @@ PROCESS
 		else 
 		{
 			$result = $false
-			$msg = "Version $installVersion is not compliant."
+			$msg = "Noncompliant version ($installVersion) detected. Upgrading to the latest PI Web API version is recommended. "
+			$msg += "See https://techsupport.osisoft.com/Products/Developer-Technologies/PI-Web-API/ for the latest version and associated documentation."
 		}	
 	}
 	catch

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -5498,10 +5498,14 @@ PROCESS
 				elseif($role.AuditRoleType -eq "PIVisionServer")
 				{ 
 					StartPIVisionServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel
+					# Call PI Web API implicitly for PI Vision audit.
 					StartPIWebApiServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel
 				}
-				elseif($role.AuditRoleType -eq "PIWebApiServer")
-				{ StartPIWebApiServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel }
+				elseif($role.AuditRoleType -eq "PIWebApiServer" -and !('PIVisionServer' -in $item.Value.AuditRoleType))
+				{ 
+					# Skip the explicit call to PI Web API audit if this machine includes a PI Vision role.
+					StartPIWebApiServerAudit $auditHashTable $role -lvl $AuditLevelInt -dbgl $DBGLevel 
+				}
 
 				$currCheck++
 			}


### PR DESCRIPTION
Version checks for PI Data Archive, PI AF, PI Vision and PI Web API now refer to the product pages for the current release so that the audit check guidance will not lag behind available releases.  

Additionally, corrected an issue where if PIWebAPIServer and PIVisionServer roles are both specified, the audit attempts to run the PIWebAPI audit twice and fails the second time.

Closes #281 