### PR TITLE
Test for registry key and return null if it is not present

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB1.psm1
@@ -784,17 +784,17 @@ PROCESS
 			# Attribute is 0 or 1 for enabled/disabled
 			$adminIsEnabled = Get-PISysAudit_RegistryKeyValue -rkp $adminKeyPath -a "IsInstalled" -lc $LocalComputer -rcn $RemoteComputerName
 			$userIsEnabled  = Get-PISysAudit_RegistryKeyValue -rkp $userKeyPath -a "IsInstalled" -lc $LocalComputer -rcn $RemoteComputerName
-			if($adminIsEnabled -and $userIsEnabled)
+			if($adminIsEnabled -eq 1 -and $userIsEnabled -eq 1)
 			{
 				$result = $true
 				$msg = "IE Enhanced Security is enabled for Users and Admins."
 			}
-			elseif($adminIsEnabled)
+			elseif($adminIsEnabled -eq 1)
 			{
 				$result = $false
 				$msg = "IE Enhanced Security is disabled for Users."
 			}
-			elseif($userIsEnabled)
+			elseif($userIsEnabled -eq 1)
 			{
 				$result = $false
 				$msg = "IE Enhanced Security is disabled for Admins."

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -2246,7 +2246,15 @@ PROCESS
 	{
 		$scriptBlock = { 
 				param([string]$Path, [string]$Name) 
-				$Value = Get-ItemProperty -Path $Path -Name $Name | Select-Object -ExpandProperty $Name 
+				if(Test-Path -Path $Path)
+				{
+					$Value = Get-ItemProperty -Path $Path -Name $Name | Select-Object -ExpandProperty $Name
+				}
+				else
+				{
+					$Value = $null
+				}
+				 
 				return $Value
 			}
 


### PR DESCRIPTION
Get-PISysAudit_RegistryKeyValue now returns null instead of throwing errors when the registry does not exist. It is a valid case for registry keys to be non-existent allowing a default behavior to be present, therefore all checks expect to handle null values for nonexistence.