### PR TITLE
Handle AF Server connections using previous object model

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -1098,7 +1098,7 @@ PROCESS
 	$msg = ""
 	try
 	{		
-		if($global:ArePowerShellToolsAvailable -and $global:AFServerConnection.ConnectionInfo.IsConnected)
+		if($global:ArePowerShellToolsAvailable -and (Test-AFServerConnectionAvailable))
 		{
 			$con = $global:AFServerConnection
 			$version = [int]($con.ServerVersion -replace '\.', '')
@@ -1222,7 +1222,7 @@ PROCESS
 	$msg = ""
 	try
 	{		
-		if($global:ArePowerShellToolsAvailable -and $global:AFServerConnection.ConnectionInfo.IsConnected)
+		if($global:ArePowerShellToolsAvailable -and (Test-AFServerConnectionAvailable))
 		{
 			$con = $global:AFServerConnection
 

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1012,6 +1012,24 @@ function Test-PowerShellToolsForPISystemAvailable
 	}
 }
 
+function Test-AFServerConnectionAvailable
+{
+<#
+.SYNOPSIS
+(Core functionality) Checks if AF Server is connected.
+.DESCRIPTION
+Validate AF Server is connected.
+#>
+    if($null -ne $global:AFServerConnection.IsConnected)
+	{
+		$global:AFServerConnection.IsConnected
+	}
+	else
+	{
+		$global:AFServerConnection.ConnectionInfo.IsConnected
+	}
+}
+
 function PathConcat {
 param(							
 		[parameter(Mandatory=$true, Position=0, ParameterSetName = "Default")]
@@ -1361,7 +1379,7 @@ param(
 			try
 			{
 				$global:AFServerConnection = Connect-AFServer -AFServer $(Get-AFServer -Name $ComputerParams.ComputerName)
-				if($global:AFServerConnection.ConnectionInfo.IsConnected)
+				if(Test-AFServerConnectionAvailable)
 				{
 					$msgTemplate = "Successfully connected to the PI AF Server {0} with PowerShell."
 					$msg = [string]::Format($msgTemplate, $ComputerParams.ComputerName)
@@ -5675,6 +5693,7 @@ Export-ModuleMember -Alias piauditparams
 Export-ModuleMember -Alias pisysauditparams
 Export-ModuleMember -Alias piaudit
 Export-ModuleMember -Alias pwdondisk
+Export-ModuleMember Test-AFServerConnectionAvailable
 Export-ModuleMember Test-PowerShellToolsForPISystemAvailable
 Export-ModuleMember Test-WebAdministrationModuleAvailable
 # </Do not remove>


### PR DESCRIPTION
Fixes issue where AF Server connections using old object model are not properly interpreted as connected.