### PR TITLE
Minor fixes during testing.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -846,7 +846,8 @@ PROCESS
 			{
 				$afServer = $global:AFServerConnection.ConnectionInfo.PISystem
 				# Get identities with Admin Right on the AF Server object
-				$afAdminIdentities = Get-AFSecurity -AFObject $afserver `
+				$afAdminIdentities = @()
+				$afAdminIdentities += Get-AFSecurity -AFObject $afserver `
 											| ForEach-Object {if($_.Rights -like '*Admin*'){$_}} `
 											| Select-Object -ExpandProperty Identity
 				# Flag if more than one Identity is an AF super user 
@@ -854,7 +855,8 @@ PROCESS
 				If($afAdminIdentities.Count -eq 1){ $hasSingleIdentity = $true }
 
 				# Find all mappings to super user identities. 
-				$afAdminMappings = Get-AFSecurityMapping -AFServer $afserver `
+				$afAdminMappings = @()
+				$afAdminMappings += Get-AFSecurityMapping -AFServer $afserver `
 											| ForEach-Object {if($_.SecurityIdentity -in $afAdminIdentities){$_}} `
 											| Select-Object Name, SecurityIdentity, Account
 				# Flag if more than one mapping exists to the AF super user 
@@ -898,12 +900,13 @@ PROCESS
 						if($hasSingleIdentity)
 						{
 							$msg = "Multiple Windows Principals mapped to an AF Identity with Admin rights.  Evaluate whether Admin rights are necessary for: "
+							foreach ($afAdminMapping in $afAdminMappings) { $msg += " Mapping-" + $afAdminMapping.Name + '; AF Identity-' + $afAdminMapping.SecurityIdentity + "|" }
 						}
 						else # Multiple Identities should not have super user access
 						{
 							$msg = "Multiple AF Identities have AF Admin rights.  Evaluate whether Admin rights are necessary for: "	
+							foreach ($afAdminIdentity in $afAdminIdentities) { $msg += " AF Identity-" + $afAdminIdentity.Name + "|" }
 						}
-						foreach ($afAdminMapping in $afAdminMappings) { $msg += " Mapping-" + $afAdminMapping.Name + '; AF Identity-' + $afAdminMapping.SecurityIdentity + "|" } 
 					}	
 				}
 				else # Evaluate well known accounts for severity


### PR DESCRIPTION
1. Corrected issue with confusing output from AF Server Admin rights check.  The output used to be the same for multiple mappings and multiple identities.  It makes more sense just to list the identities when they are the issue.  Also initialized the variable as an array so that Count is available in all cases.
2. Return null when an environmental variable is absent rather than throwing an error.  Logic should account for null values.  The null value PowerShell error is not useful to users without additional context.  
3. Return a PISysAuditError entry for the report when a PI Data Archive audit is skipped due to the role missing.
4. Closes #298 
 