### PR TITLE
Added AFServer parameter to xAFAttribute schema.

### DIFF
--- a/PISecurityAuditDSC/Configuration/PIWebAPI_1.10.0_SecurityBaseline.ps1
+++ b/PISecurityAuditDSC/Configuration/PIWebAPI_1.10.0_SecurityBaseline.ps1
@@ -27,24 +27,9 @@ to the PI Web API.
 
 .EXAMPLE
 
-.\PIWebAPI_1.10.0_SecurityBaseline -NodeName "myPIWebAPI" -PIWebAPIConfigElementPath "\\myAF\Configuration\OSIsoft\PI Web API\myPIWebAPI\System Configuration" -CorsOrigins "https://myPIWebAPI,https://myPIWebAPI.domain.int"
+.\PIWebAPI_1.10.0_SecurityBaseline -PIWebAPINodeName "myPIWebAPI" -AFServer "myAFServer" -PIWebAPIConfigElementPath "Configuration\OSIsoft\PI Web API\myPIWebAPI\System Configuration" -CorsOrigins "https://myPIWebAPI,https://myPIWebAPI.domain.int"
 
 #>
-param
-(
-    [parameter(Mandatory=$true)]
-    [string]
-    $NodeName,
-
-    [parameter(Mandatory=$true)]
-    [string]
-    $PIWebAPIConfigElementPath,
-
-    [parameter(Mandatory=$true)]
-    [string]
-    $CorsOrigins
-)
-
 
 Configuration PIWebAPI_1.10.0_SecurityBaseline
 {
@@ -52,7 +37,11 @@ Configuration PIWebAPI_1.10.0_SecurityBaseline
     (
         [parameter(Mandatory=$true)]
         [string]
-        $NodeName,
+        $PIWebAPINodeName,
+
+        [parameter(Mandatory=$true)]
+        [string]
+        $AFServer,
 
         [parameter(Mandatory=$true)]
         [string]
@@ -140,7 +129,7 @@ Configuration PIWebAPI_1.10.0_SecurityBaseline
         }
     )
 
-    Node $NodeName
+    Node $PIWebAPINodeName
     {
         foreach($attribute in $configAttributes.GetEnumerator())
         {
@@ -148,6 +137,7 @@ Configuration PIWebAPI_1.10.0_SecurityBaseline
             {
                 AFAttribute $attribute.Name
                 {
+                    AFServer = $AFServer
                     ElementPath = $PIWebAPIConfigElementPath
                     Name = $attribute.Name
                     Type = $attribute.Type
@@ -160,6 +150,7 @@ Configuration PIWebAPI_1.10.0_SecurityBaseline
     }
 }
 
-PIWebAPI_1.10.0_SecurityBaseline -NodeName $NodeName `
+PIWebAPI_1.10.0_SecurityBaseline -PIWebAPINodeName $PIWebAPINodeName `
+    -AFServer $AFServer `
     -PIWebAPIConfigElementPath $PIWebAPIConfigElementPath `
     -CorsOrigins $CorsOrigins

--- a/PISecurityAuditDSC/Configuration/PIWebAPI_1.9.0_SecurityBaseline.ps1
+++ b/PISecurityAuditDSC/Configuration/PIWebAPI_1.9.0_SecurityBaseline.ps1
@@ -27,24 +27,9 @@ to the PI Web API.
 
 .EXAMPLE
 
-.\PIWebAPI_1.9.0_SecurityBaseline -NodeName "myPIWebAPI" -PIWebAPIConfigElementPath "\\myAF\Configuration\OSIsoft\PI Web API\myPIWebAPI\System Configuration" -CorsOrigins "https://myPIWebAPI,https://myPIWebAPI.domain.int"
+.\PIWebAPI_1.9.0_SecurityBaseline -PIWebAPINodeName "myPIWebAPI" -AFServer "myAF" -PIWebAPIConfigElementPath "Configuration\OSIsoft\PI Web API\myPIWebAPI\System Configuration" -CorsOrigins "https://myPIWebAPI,https://myPIWebAPI.domain.int"
 
 #>
-param
-(
-    [parameter(Mandatory=$true)]
-    [string]
-    $NodeName,
-
-    [parameter(Mandatory=$true)]
-    [string]
-    $PIWebAPIConfigElementPath,
-
-    [parameter(Mandatory=$true)]
-    [string]
-    $CorsOrigins
-)
-
 
 Configuration PIWebAPI_1.9.0_SecurityBaseline
 {
@@ -52,7 +37,11 @@ Configuration PIWebAPI_1.9.0_SecurityBaseline
     (
         [parameter(Mandatory=$true)]
         [string]
-        $NodeName,
+        $PIWebAPINodeName,
+
+        [parameter(Mandatory=$true)]
+        [string]
+        $AFServer,
 
         [parameter(Mandatory=$true)]
         [string]
@@ -122,7 +111,7 @@ Configuration PIWebAPI_1.9.0_SecurityBaseline
         }
     )
 
-    Node $NodeName
+    Node $PIWebAPINodeName
     {
         foreach($attribute in $configAttributes.GetEnumerator())
         {
@@ -130,6 +119,7 @@ Configuration PIWebAPI_1.9.0_SecurityBaseline
             {
                 AFAttribute $attribute.Name
                 {
+                    AFServer = $AFServer
                     ElementPath = $PIWebAPIConfigElementPath
                     Name = $attribute.Name
                     Type = $attribute.Type
@@ -142,6 +132,7 @@ Configuration PIWebAPI_1.9.0_SecurityBaseline
     }
 }
 
-PIWebAPI_1.9.0_SecurityBaseline -NodeName $NodeName `
+PIWebAPI_1.9.0_SecurityBaseline -PIWebAPINodeName $PIWebAPINodeName `
+    -AFServer $AFServer `
     -PIWebAPIConfigElementPath $PIWebAPIConfigElementPath `
     -CorsOrigins $CorsOrigins

--- a/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/xAFAttribute/xAFAttribute.psm1
+++ b/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/xAFAttribute/xAFAttribute.psm1
@@ -41,6 +41,23 @@
     }
 }
 
+function ConvertTo-FullPath
+{
+param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AFServer,
+        
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ElementPath
+)
+
+$FullPath = "\\" + $AFServer.Trim("\") + "\" + $ElementPath.Trim("\")
+
+return $FullPath
+}
+
 function Get-TargetResource
 {
     [cmdletbinding()]
@@ -49,6 +66,10 @@ function Get-TargetResource
         [ValidateSet("Present", "Absent")]
         [string]$Ensure = "Present",
 
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AFServer,
+        
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$ElementPath,
@@ -72,7 +93,7 @@ function Get-TargetResource
     $attributeType = $null
     $attributeIsArray = $null
 
-    
+    $ElementPath = ConvertTo-FullPath -AFServer $AFServer -ElementPath $ElementPath
     # Load AF SDK. Calling this while it's already loaded shouldn't be harmful
     $loaded = [System.Reflection.Assembly]::LoadWithPartialName("OSIsoft.AFSDK")
     if ($null -eq $loaded) {
@@ -132,6 +153,10 @@ function Set-TargetResource
     (
         [ValidateSet("Present", "Absent")]
         [string]$Ensure = "Present",
+        
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$AFServer,
 
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -149,7 +174,8 @@ function Set-TargetResource
         [boolean]$IsArray = $false
     )
 
-    # Load AF SDK. Calling this while it's already loaded shouldn't be harmful
+    $ElementPath = ConvertTo-FullPath -AFServer $AFServer -ElementPath $ElementPath
+    # Load AF SDK. Calling this while it's already loaded by PowerShell tools shouldn't be harmful
     $loaded = [System.Reflection.Assembly]::LoadWithPartialName("OSIsoft.AFSDK")
     if ($null -eq $loaded) {
         $ErrorActionPreference = 'Stop'
@@ -261,6 +287,10 @@ function Test-TargetResource
 
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
+        [string]$AFServer,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$ElementPath,
 
         [Parameter(Mandatory)]
@@ -275,7 +305,7 @@ function Test-TargetResource
         [boolean]$IsArray = $false
     )
 
-    $result = Get-TargetResource -Ensure Present -ElementPath $ElementPath -Name $Name
+    $result = Get-TargetResource -Ensure Present -ElementPath $ElementPath -Name $Name -AFServer $AFServer
     $ensureMatch = $result.Ensure -eq $Ensure
     $typeMatch = $result.Type -eq $Type
     $arrayMatch = $result.IsArray -eq $IsArray

--- a/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/xAFAttribute/xAFAttribute.schema.mof
+++ b/PISecurityAuditDSC/Module/PISecurityDSC/DSCResources/xAFAttribute/xAFAttribute.schema.mof
@@ -1,10 +1,11 @@
 [ClassVersion("1.0.0"), FriendlyName("AFAttribute")]
 class xAFAttribute : OMI_BaseResource
 {
-    [Key] string Name;
-    [Required, Description("Specifies the full path to the Element")] string ElementPath;
-    [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
-    [write] string Value[];
-    [write,ValueMap{"Boolean", "Byte", "DateTime", "Double", "Int16", "Int32", "Int64", "Single", "String"},Values{"Boolean", "Byte", "DateTime", "Double", "Int16", "Int32", "Int64", "Single", "String"}] string Type;
-    [write] Boolean IsArray;
+    [Key, Description("Specifies the name of the attribute.")] string Name;
+	[Key, Description("Specifies the path from the database to the Element.")] string ElementPath;
+    [Key] string AFServer;
+	[Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
+    [Write] string Value[];
+    [Write,ValueMap{"Boolean", "Byte", "DateTime", "Double", "Int16", "Int32", "Int64", "Single", "String"},Values{"Boolean", "Byte", "DateTime", "Double", "Int16", "Int32", "Int64", "Single", "String"}] string Type;
+    [Write] Boolean IsArray;
 };


### PR DESCRIPTION
Added AFServer to the schema of xAFAttribute to make it more consistent with the other AF Resources and made AF Server, Path and Name keys so that there are not collisions for the same item on multiple elements or servers.  Updated the example files with the new schema since the schema change is a breaking change.

Closes #337 