### PR TITLE
Handle SID when checking privilege

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -326,7 +326,8 @@ PROCESS
 				
 				if($null -ne $listOfPrivileges)
 				{
-					# Read each line to find granted privileges.		
+					$result = $true
+                    # Read each line to find granted privileges.		
 					foreach($line in $listOfPrivileges)
 					{											
 						# Reset.					
@@ -350,8 +351,8 @@ PROCESS
 						$msg = "The account has the following privileges: " + $msg + "." 
 					}
 					else 
-					{ 
-						$msg = "No weaknesses were detected."
+					{
+                        $msg = "No weaknesses were detected."
 					}
 				}
 				else


### PR DESCRIPTION
Properly handle account SID when checking privilege locally. Suppress standard output success message from cmdline utility.
Fixes #356 