### PR TITLE
Implemented Alias for PI Vision checks

### DIFF
--- a/PISecurityAudit/Readme.txt
+++ b/PISecurityAudit/Readme.txt
@@ -130,6 +130,7 @@ $cpt = piauditparams $null "myPIServer" "PIDataArchive"
 $cpt = piauditparams $cpt "myPIAFServer" "PIAFServer"
 $cpt = piauditparams $cpt "mySQLServer" "SQLServer" -InstanceName "myinstance" # -IntegratedSecurity $false -user "sa" -pf "p1.dat"
 $cpt = piauditparams $cpt "myPIVision" "PIVisionServer"
+$cpt = piauditparams $cpt "myPIVision2" "PIVisionServer" -Alias "myPV.example.org"
 piaudit -cpt $cpt
 
 # Example 3

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB5.psm1
@@ -150,7 +150,6 @@ PROCESS
 			$Configuration | Add-Member -MemberType NoteProperty -Name sslFlagsSite -Value $sslFlagsSite
 			$Configuration | Add-Member -MemberType NoteProperty -Name sslFlagsApp -Value $sslFlagsApp
 			$Configuration | Add-Member -MemberType NoteProperty -Name customHeaders -Value $customHeaders
-			$Configuration | Add-Member -MemberType NoteProperty -Name Alias -Value $Alias
 			
 			return $Configuration
 		}
@@ -160,6 +159,11 @@ PROCESS
 		{ $global:PIVisionConfiguration = & $scriptBlock }
 		else
 		{ $global:PIVisionConfiguration = Invoke-Command -ComputerName $RemoteComputerName -ScriptBlock $scriptBlock }
+		
+		if(![string]::IsNullOrEmpty($Alias))
+		{
+		    $global:PIVisionConfiguration | Add-Member -MemberType NoteProperty -Name Alias -Value $Alias
+	    }
 	}
 	catch
 	{
@@ -581,7 +585,7 @@ PROCESS
 		$serviceName = "pivision"
 		
 		# Use alias if specified, otherwise check for the custom host header
-		if($global:PIVisionConfiguration.Alias -ne "")
+		if(![string]::IsNullOrEmpty($global:PIVisionConfiguration.Alias))
 		{
 			$CustomHeader = $global:PIVisionConfiguration.Alias
 			$serviceName = "pivision_custom"

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -1653,7 +1653,7 @@ param(
 		try
 		{
 			Write-Progress -Activity $activityMsg1 -Status "Gathering PI Vision Configuration" -ParentId 1
-			Get-PISysAudit_GlobalPIVisionConfiguration -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName -DBGLevel $DBGLevel 
+			Get-PISysAudit_GlobalPIVisionConfiguration -lc $ComputerParams.IsLocal -rcn $ComputerParams.ComputerName -al $ComputerParams.Alias -DBGLevel $DBGLevel 
 		}
 		catch
 		{
@@ -4115,6 +4115,9 @@ PROCESS
 		
 		# Run setspn. Redirect stderr to null to prevent errors from bubbling up
 		$spnCheck = $(setspn -l $accountNane 2>$null) 
+		
+		$msg = "SPN query returned: $spnCheck"					
+		Write-PISysAudit_LogMessage $msg "debug" $fn -dbgl $DBGLevel -rdbgl 2
 
 		# Null if something went wrong
 		if($null -eq $spnCheck)
@@ -4123,7 +4126,16 @@ PROCESS
 			Write-PISysAudit_LogMessage $msg "Error" $fn
 			return $false
 		}
-		
+						
+		if($blnAlias)
+		{
+			$msg = "Searching for SPNs: $SPNShort, $SPNLong, $SPNShortAlias, $SPNLongAlias"					
+		}
+		else
+		{
+			$msg = "Searching for SPNs: $SPNShort, $SPNLong"
+		}
+		Write-PISysAudit_LogMessage $msg "debug" $fn -dbgl $DBGLevel -rdbgl 2
 		# Loop through SPNs, trimming and ensure all lower for comparison
 		$spnCounter = 0
 		foreach($line in $spnCheck)
@@ -4443,6 +4455,13 @@ PROCESS
 																-SQLServerUserID $ComputerParameter.SQLServerUserID `
 																-PasswordFile $ComputerParameter.PasswordFile
 		}
+		ElseIf($null -ne ($ComputerParameter | Get-Member -Name Alias))
+		{
+			$ComputerParamsTable = New-PISysAuditComputerParams -ComputerParamsTable $ComputerParamsTable `
+																-ComputerName $ComputerParameter.ComputerName `
+																-PISystemComponent $ComputerParameter.PISystemComponentType `
+																-Alias $ComputerParameter.Alias
+		}
 		Else
 		{
 			$ComputerParamsTable = New-PISysAuditComputerParams -ComputerParamsTable $ComputerParamsTable `
@@ -4700,6 +4719,9 @@ is configured, the end-user will be prompted to enter the password once. This
 password will be kept securely in memory until the end of the execution.
 .PARAMETER showui
 Output messages on the command prompt or not.
+.PARAMETER Alias
+Name other than the machine name used by clients to access the server.
+Presently only used by PI Vision checks.
 .EXAMPLE
 $cpt = New-PISysAuditComputerParams -cpt $cpt -cn "MyPIServer" -type "pi"
 The -cpt will use the hashtable of parameters to know how to audit
@@ -4745,6 +4767,10 @@ param(
 		[alias("pf")]
 		[string]
 		$PasswordFile = "",
+		[parameter(Mandatory=$false, ParameterSetName = "Default")]		
+		[alias("al")]
+		[string]
+		$Alias = "",
 		[parameter(Mandatory=$false, ParameterSetName = "Default")]				
 		[boolean]
 		$ShowUI = $true)
@@ -4804,52 +4830,31 @@ PROCESS
 	# ............................................................................................................	
 	# Create a custom object (PISysAuditComputerParams).
 	$tempObj = New-Object PSCustomObject
-	
-	if(($PISystemComponentType.ToLower() -eq "piserver") -or `
-		($PISystemComponentType.ToLower() -eq "pidataarchive") -or `
-		($PISystemComponentType.ToLower() -eq "pida") -or `
-		($PISystemComponentType.ToLower() -eq "dataarchive"))
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $null	
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "Alias" -Value $null
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $null
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IntegratedSecurity" -Value $null	
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "SQLServerUserID" -Value $null
+	Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "PasswordFile" -Value $null	
+
+	if($PISystemComponentType.ToLower() -in @("piserver","pidataarchive","pida","dataarchive"))
 	{
-		# Set the properties.
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer		
-		# Use normalized type description as 'PIDataArchive'
-		$AuditRoleType = "PIDataArchive"
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $AuditRoleType
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IntegratedSecurity" -Value $null	
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "SQLServerUserID" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "PasswordFile" -Value $null		
+		$tempObj.AuditRoleType = "PIDataArchive"
 	}
-	elseif(($PISystemComponentType.ToLower() -eq "piafserver") -or `
-		($PISystemComponentType.ToLower() -eq "afserver") -or `
-		($PISystemComponentType.ToLower() -eq "piaf") -or `
-		($PISystemComponentType.ToLower() -eq "af"))
-	{
-		# Set the properties.
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer		
-		# Use normalized type description as 'PIAFServer'
-		$AuditRoleType = "PIAFServer"
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $AuditRoleType
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IntegratedSecurity" -Value $null	
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "SQLServerUserID" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "PasswordFile" -Value $null		
+	elseif($PISystemComponentType.ToLower() -in @("piafserver","afserver","piaf","af"))
+	{	
+		$tempObj.AuditRoleType = "PIAFServer"
 	}
-	elseif(($PISystemComponentType.ToLower() -eq "sqlserver") -or `
-		($PISystemComponentType.ToLower() -eq "sql"))
-	{		
-		# Set the properties.
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer		
-		# Use normalized type description as 'SQLServer'
-		$AuditRoleType = "SQLServer"
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $AuditRoleType
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $InstanceName
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IntegratedSecurity" -Value $IntegratedSecurity	
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "SQLServerUserID" -Value $SQLServerUserID
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "PasswordFile" -Value $PasswordFile				
+	elseif($PISystemComponentType.ToLower() -in @("sqlserver","sql"))
+	{			
+		$tempObj.AuditRoleType = "SQLServer"
+		$tempObj.InstanceName = $InstanceName
+		$tempObj.IntegratedSecurity = $IntegratedSecurity	
+		$tempObj.InstanceName = $InstanceName
+		$tempObj.SQLServerUserID = $SQLServerUserID
+		$tempObj.PasswordFile = $PasswordFile		
 		
 		# Test if a user name has been passed if Window integrated security is not used
 		if($IntegratedSecurity -eq $false)
@@ -4889,48 +4894,14 @@ PROCESS
 			}
 		}	
 	}
-	elseif (($PISystemComponentType.ToLower() -eq "picoresightserver") -or `
-		($PISystemComponentType.ToLower() -eq "picoresight") -or `
-		($PISystemComponentType.ToLower() -eq "coresightserver") -or `
-		($PISystemComponentType.ToLower() -eq "coresight") -or `
-		($PISystemComponentType.ToLower() -eq "cs") -or `
-		($PISystemComponentType.ToLower() -eq "pics") -or `
-		($PISystemComponentType.ToLower() -eq "pivision") -or `
-		($PISystemComponentType.ToLower() -eq "visionserver") -or `
-		($PISystemComponentType.ToLower() -eq "vision") -or `
-		($PISystemComponentType.ToLower() -eq "pivisionserver") -or `
-		($PISystemComponentType.ToLower() -eq "pv")
-	)
-	{
-		# Set the properties.
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer		
-		# Use normalized type description as 'PIVisionServer'
-		$AuditRoleType = "PIVisionServer"
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $AuditRoleType
-		# Nullify all of the MS SQL specific values
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IntegratedSecurity" -Value $null	
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "SQLServerUserID" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "PasswordFile" -Value $null		
+	elseif ($PISystemComponentType.ToLower() -in @("picoresightserver","picoresight","coresightserver","coresight","cs","pics","pivision","visionserver","vision","pivisionserver","pv"))
+	{		
+		$tempObj.AuditRoleType = "PIVisionServer"	
+		$tempObj.Alias = $Alias
 	}
-	elseif (($PISystemComponentType.ToLower() -eq "piwebapiserver") -or `
-		($PISystemComponentType.ToLower() -eq "piwebapi") -or `
-		($PISystemComponentType.ToLower() -eq "webapiserver") -or `
-		($PISystemComponentType.ToLower() -eq "webapi")
-	)
+	elseif ($PISystemComponentType.ToLower() -in @("piwebapiserver","piwebapi","webapiserver","webapi"))
 	{
-		# Set the properties.
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "ComputerName" -Value $resolvedComputerName
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IsLocal" -Value $localComputer		
-		# Use normalized type description as 'PIWebApiServer'
-		$AuditRoleType = "PIWebApiServer"
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "AuditRoleType" -Value $AuditRoleType
-		# Nullify all of the MS SQL specific values
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "InstanceName" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "IntegratedSecurity" -Value $null	
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "SQLServerUserID" -Value $null
-		Add-Member -InputObject $tempObj -MemberType NoteProperty -Name "PasswordFile" -Value $null
+		$tempObj.AuditRoleType = "PIWebApiServer"
 	}
 
 	# Add hashtable item and computer audit if not already in params table

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -3811,7 +3811,7 @@ PROCESS
 				$result = Test-PISysAudit_ServicePrincipalName -HostName $hostname -MachineDomain $MachineDomain `
 																-SPNShort $hostnameSPN -SPNLong $fqdnSPN `
 																-SPNShortAlias $CustomHeaderSPN -SPNLongAlias $CustomHeaderLongSPN `
-																-TargetAccountName $svcaccParsed.UserName -ServiceAccountDomain $svcaccParsed.Domain -DBGLevel $DBGLevel
+																-TargetAccountName $svcaccParsed.UserName -TargetDomain $svcaccParsed.Domain -DBGLevel $DBGLevel
 						
 				return $result			
 			} 			


### PR DESCRIPTION
The PI Vision audit checks relied too heavily on the custom host header to identify an alternative name that clients would use.  This set of changes allows users to specify an alias for PI Vision checks.  Presently, the only check that takes advantage of this is the SPN check, but there could be opportunities elsewhere.  PI Web API may benefit from this in the future also.

Additional changes include refactoring the initialization of the computer parameters to make it more clear what is set uniquely for each role and debug messages for the SPN test command so that failures will be easier to troubleshoot in the future. 