### PR TITLE
Improved privilege check

### DIFF
--- a/PISecurityAudit/PISecurityAudit.pssproj
+++ b/PISecurityAudit/PISecurityAudit.pssproj
@@ -45,6 +45,7 @@
     <Compile Include="Scripts\PISYSAUDIT\PISYSAUDITCHECKLIB6.psm1" />
     <Compile Include="Scripts\PISYSAUDIT\PISYSAUDITCORE.psm1" />
     <Compile Include="Scripts\UpdateValidationsInHelp.ps1" />
+    <Compile Include="Scripts\Utilities\CheckProcessPrivilege.ps1" />
     <Compile Include="Scripts\Utilities\PIVISIONKERBEROSCONFIGURATION.psm1" />
     <Compile Include="Scripts\Utilities\PISECCONFIGEXPORT.psm1" />
     <Compile Include="Testing\ExecutePester.ps1" />

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -312,7 +312,7 @@ PROCESS
 			$privilegeFound = $false		
 		
 			# Get the service account.
-			$listOfPrivileges = Get-PISysAudit_ServicePrivilege -lc $LocalComputer -rcn $RemoteComputerName -sn "piarchss" -dbgl $DBGLevel					
+			$listOfPrivileges = Get-PISysAudit_ServicePrivilege -lc $LocalComputer -rcn $RemoteComputerName -sn "AFService" -dbgl $DBGLevel					
 		
 			# Read each line to find granted privileges.		
 			foreach($line in $listOfPrivileges)

--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCHECKLIB3.psm1
@@ -290,77 +290,75 @@ PROCESS
 	$msg = ""
 	try
 	{										
-		$ServiceName = 'afservice'
-		$ServiceAccount = Get-PISysAudit_ServiceProperty -sn $ServiceName -sp LogOnAccount -lc $LocalComputer -rcn $RemoteComputerName -dbgl $DBGLevel
-		# No need to check specific privileges if the service account is an admin.
-		$IsServiceAccountLocalAdmin = Get-PISysAudit_GroupMembers -GroupName "Administrators" -GroupDomain "local" -LocalComputer $LocalComputer -RemoteComputerName $RemoteComputerName -CheckUser $ServiceAccount
-		if($ServiceAccount.ToLower() -eq $('nt service\' + $ServiceName))
+		$IsElevated = (Get-Variable "PISysAuditIsElevated" -Scope "Global" -ErrorAction "SilentlyContinue").Value
+		# Verify running elevated.
+		if(-not($IsElevated))
 		{
-			$result = $true
-			$msg = "The service account is the default virtual account."
+			$msg = "Elevation required to check process privilege.  Run Powershell as Administrator to complete this check"
+			Write-PISysAudit_LogMessage $msg "Warning" $fn
+			$result = "N/A"
 		}
-		elseif($IsServiceAccountLocalAdmin)
+		elseif($ExecutionContext.SessionState.LanguageMode -eq "ConstrainedLanguage")
 		{
-			$result = $false
-			$msg = "The service account is in the local Administrators group."
+			$msg = "Constrained Language Mode detected.  This check will be skipped"
+			Write-PISysAudit_LogMessage $msg "Warning" $fn
+			$result = "N/A"
 		}
 		else
 		{
-			$IsElevated = (Get-Variable "PISysAuditIsElevated" -Scope "Global" -ErrorAction "SilentlyContinue").Value
-			# Verify running elevated.
-			if($LocalComputer -and (-not $IsElevated))
-			{
-				$msg = "Elevation required to check process privileges.  Run Powershell as Administrator to complete this check"
-				Write-PISysAudit_LogMessage $msg "Warning" $fn
-				$result = "N/A"
-			}
-			else
-			{
-				# Initialize objects.
-				$securityWeaknessCounter = 0	
-				$securityWeakness = $false
-				$privilegeFound = $false		
+			# Initialize objects.
+			$securityWeaknessCounter = 0	
+			$securityWeakness = $false
+			$privilegeFound = $false		
 		
-				# Get the service account.
-				$listOfPrivileges = Get-PISysAudit_CheckPrivilege -lc $LocalComputer -rcn $RemoteComputerName -an $ServiceAccount -dbgl $DBGLevel					
+			# Get the service account.
+			$listOfPrivileges = Get-PISysAudit_ServicePrivilege -lc $LocalComputer -rcn $RemoteComputerName -sn "piarchss" -dbgl $DBGLevel					
+		
+			# Read each line to find granted privileges.		
+			foreach($line in $listOfPrivileges)
+			{											
+				# Reset.
+				$securityWeakness = $false						
+				$privilegeFound = $false			
+			
+				# Skip any line not starting with 'SE'
+				if($line.ToUpper().StartsWith("SE")) 
+				{								
+					# Validate that the tokens contains these privileges.
+					if($line.ToUpper().Contains("SEDEBUGPRIVILEGE")) { $privilegeFound = $true }
+					if($line.ToUpper().Contains("SETAKEOWNERSHIPPRIVILEGE")) { $privilegeFound = $true }
+					if($line.ToUpper().Contains("SETCBPRIVILEGE")) { $privilegeFound = $true }
 				
-				if($null -ne $listOfPrivileges)
+					# Validate that the privilege is enabled, if yes a weakness was found.
+					if($privilegeFound -and ($line.ToUpper().Contains("ENABLED"))) { $securityWeakness = $true }
+				}							
+
+				# Increment the counter if a weakness has been discovered.
+				if($securityWeakness)
 				{
-					$result = $true
-                    # Read each line to find granted privileges.		
-					foreach($line in $listOfPrivileges)
-					{											
-						# Reset.					
-						$privilegeFound = $false			
-					
-						# Skip any line not starting with 'SE'
-						if($line.ToUpper().StartsWith("SE")) 
-						{								
-							# Validate that the tokens contains these privileges.
-							if($line.ToUpper().Contains("SEDEBUGPRIVILEGE")) { $privilegeFound = $true }
-							if($line.ToUpper().Contains("SETAKEOWNERSHIPPRIVILEGE")) { $privilegeFound = $true }
-							if($line.ToUpper().Contains("SETCBPRIVILEGE")) { $privilegeFound = $true }
-							if($privilegeFound){
-								$result = $false
-								$msg = $msg + ", " + $line.ToUpper()
-							}
-						}						
-					}	
-					if($result -eq $false)
-					{
-						$msg = "The account has the following privileges: " + $msg + "." 
-					}
-					else 
-					{
-                        $msg = "No weaknesses were detected."
-					}
-				}
+					$securityWeaknessCounter++
+				
+					# Store the privilege found that might compromise security.
+					if($securityWeaknessCounter -eq 1)
+					{ $msg = $line.ToUpper() }
+					else
+					{ $msg = $msg + ", " + $line.ToUpper() }
+				}					
+			}
+		
+			# Check if the counter is 0 = compliant, 1 or more it is not compliant		
+			if($securityWeaknessCounter -gt 0)
+			{
+				$result = $false
+				if($securityWeaknessCounter -eq 1)
+				{ $msg = "The following privilege: " + $msg + " is enabled." }
 				else
-				{
-					$result = "N/A"
-					$msg = "Unable to complete AF Server service privilege check."
-				}
-				
+				{ $msg = "The following privileges: " + $msg + " are enabled." }
+			}
+			else 
+			{ 
+				$result = $true 
+				$msg = "No weaknesses were detected."
 			}
 		}	
 	}

--- a/PISecurityAudit/Scripts/Utilities/CheckProcessPrivilege.ps1
+++ b/PISecurityAudit/Scripts/Utilities/CheckProcessPrivilege.ps1
@@ -1,0 +1,145 @@
+# ************************************************************************
+# *
+# * Copyright 2016 OSIsoft, LLC
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# * 
+# *   <http://www.apache.org/licenses/LICENSE-2.0>
+# * 
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# ************************************************************************
+
+[CmdletBinding(DefaultParameterSetName="Default", SupportsShouldProcess=$false)]     
+param(			
+		[parameter(Mandatory=$true, Position=0, ParameterSetName = "Default")]
+		[int32]
+		$ProcessId
+)
+
+$code = @'
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+public class HelperPrivilege
+{
+    enum TOKEN_INFORMATION_CLASS
+    {
+        TokenUser = 1,
+        TokenGroups,
+        TokenPrivileges,
+        TokenOwner,
+        TokenPrimaryGroup,
+        TokenDefaultDacl,
+        TokenSource,
+        TokenType,
+        TokenImpersonationLevel,
+        TokenStatistics,
+        TokenRestrictedSids,
+        TokenSessionId,
+        TokenGroupsAndPrivileges,
+        TokenSessionReference,
+        TokenSandBoxInert,
+        TokenAuditPolicy,
+        TokenOrigin
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct LUID
+    {
+        public uint LowPart;
+        public int HighPart;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct LUID_AND_ATTRIBUTES
+    {
+        public LUID Luid;
+        public uint Attributes;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct TOKEN_PRIVILEGES
+    {
+        public uint Count;
+    }
+
+    [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+    static extern bool OpenProcessToken(IntPtr ProcessHandle, int Access, ref IntPtr phToken);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool GetTokenInformation(IntPtr TokenHandle, TOKEN_INFORMATION_CLASS TokenInformationClass, IntPtr TokenInformation, uint TokenInformationLength, out uint ReturnLength);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    public static extern bool LookupPrivilegeName(string lpSystemName, IntPtr lpLuid, StringBuilder lpName, ref int cchName);
+
+    static public List<string> EnumRights(int processId)
+    {
+        uint tokenInfoLength = 0;
+        const int TOKEN_QUERY = 0x00000008;
+        const UInt32 SE_PRIVILEGE_ENABLED_BY_DEFAULT = 0x00000001;
+        const UInt32 SE_PRIVILEGE_ENABLED = 0x00000002;
+        const UInt32 SE_PRIVILEGE_REMOVED = 0x00000004;
+        const UInt32 SE_PRIVILEGE_USER_FOR_ACCESS = 0x80000000;
+        List<string> privilegesList = new List<string>();
+        Process targetProcess = Process.GetProcessById(processId);
+        if (targetProcess == null)
+        { privilegesList.Add("No Process"); }
+        else
+        {
+            IntPtr htok = IntPtr.Zero;
+            bool returnValue = OpenProcessToken(targetProcess.Handle, TOKEN_QUERY, ref htok);
+            bool result = GetTokenInformation(htok, TOKEN_INFORMATION_CLASS.TokenPrivileges, IntPtr.Zero, tokenInfoLength, out tokenInfoLength);
+            IntPtr tokenInformation = Marshal.AllocHGlobal(unchecked((int)tokenInfoLength));
+            result = GetTokenInformation(htok, TOKEN_INFORMATION_CLASS.TokenPrivileges, tokenInformation, tokenInfoLength, out tokenInfoLength);
+            if (result)
+            {
+                TOKEN_PRIVILEGES privileges = (TOKEN_PRIVILEGES)Marshal.PtrToStructure(tokenInformation, typeof(TOKEN_PRIVILEGES));
+                for (int i = 0; i < privileges.Count; i++)
+                {
+                    IntPtr ptr = new IntPtr(tokenInformation.ToInt64() + sizeof(uint) + i * Marshal.SizeOf(typeof(LUID_AND_ATTRIBUTES)));
+                    LUID_AND_ATTRIBUTES privilegeInfo = (LUID_AND_ATTRIBUTES)Marshal.PtrToStructure(ptr, typeof(LUID_AND_ATTRIBUTES));
+                    StringBuilder name = new StringBuilder();
+                    string value = "";
+                    IntPtr luidPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LUID)));
+                    Marshal.StructureToPtr(privilegeInfo.Luid, luidPtr, false);
+                    int nameLength = 0;
+                    LookupPrivilegeName(null, luidPtr, null, ref nameLength);
+                    name.EnsureCapacity(nameLength);
+                    LookupPrivilegeName(null, luidPtr, name, ref nameLength);
+                    if (privilegeInfo.Attributes == 0)
+                    { value = "=Disabled"; }
+                    if ((privilegeInfo.Attributes & SE_PRIVILEGE_ENABLED) == SE_PRIVILEGE_ENABLED)
+                    {
+                        if ((privilegeInfo.Attributes & SE_PRIVILEGE_ENABLED_BY_DEFAULT) == SE_PRIVILEGE_ENABLED_BY_DEFAULT)
+                        { value = "=Default,Enabled"; }
+                        else
+                        { value = "=Enabled"; }
+                    }
+                    if ((privilegeInfo.Attributes & SE_PRIVILEGE_REMOVED) == SE_PRIVILEGE_REMOVED)
+                    { value = "=Removed"; }
+                    if ((privilegeInfo.Attributes & SE_PRIVILEGE_USER_FOR_ACCESS) == SE_PRIVILEGE_USER_FOR_ACCESS)
+                    { value = "=UsedforAccess"; }
+                    Marshal.FreeHGlobal(luidPtr);
+                    privilegesList.Add(name.ToString() + value);
+                }
+            }
+            Marshal.FreeHGlobal(tokenInformation);
+        }
+        return privilegesList;
+    }
+}
+'@
+
+# Dynamically load the C# code in memory.
+$dynamicType = Add-Type -TypeDefinition $code -PassThru -Language "CSharp"
+$privilegesList = $dynamicType[0]::EnumRights($ProcessId)
+
+return $privilegesList


### PR DESCRIPTION
The privilege check was switched from an implementation using pinvoke code to an alternative using secedit so that ConstrainedLanguageMode would not interfere with the check.  The secedit implementation relied on WMI queries to tie account SIDs to the dumped privileges.  This resulted in poor coverage since privileges inherited from a group were not considered and domain users could not be resolved remotely.  Furthermore, constrained language mode has not been widely encountered in actual customer environments.

This pull request re-implements a pinvoke code method with a simplified approach.  The process is primarily identified by the ID rather than the name as in the previous implementation.  There is a check if ConstrainedLanguageMode is set, and if so, the check is skipped with a Warning.