### PR TITLE
Using literal path where we don't need wildcards.

### DIFF
--- a/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
+++ b/PISecurityAudit/Scripts/PISYSAUDIT/PISYSAUDITCORE.psm1
@@ -2000,8 +2000,8 @@ Read a value from the Windows Registry Hive.
         try {
             $scriptBlock = {
                 param([string]$Path, [string]$Name)
-                if (Test-Path -Path $Path) {
-                    $Value = Get-ItemProperty -Path $Path -Name $Name | Select-Object -ExpandProperty $Name
+                if (Test-Path -LiteralPath $Path) {
+                    $Value = Get-ItemProperty -LiteralPath $Path -Name $Name | Select-Object -ExpandProperty $Name
                 }
                 else {
                     $Value = $null
@@ -2501,7 +2501,7 @@ Get installed software on a given computer.
                 param([string]$RegKey)
                 if ($RegKey -like 'Wow6432') { $Action = 'SilentlyContinue' }
                 else { $Action = 'Continue' }
-                Get-ChildItem $RegKey -ErrorAction $Action | ForEach-Object { Get-ItemProperty $_.PsPath } | Where-Object { $_.Displayname -and ($_.Displayname -match ".*") }
+                Get-ChildItem -LiteralPath $RegKey -ErrorAction $Action | ForEach-Object { Get-ItemProperty -LiteralPath $_.PsPath } | Where-Object { $_.Displayname -and ($_.Displayname -match ".*") }
             }
 
             if ($LocalComputer) {
@@ -2820,7 +2820,7 @@ Get the servers in the PI Data Archive or PI AF Server KST.
     If ($ServerType -eq 'PIServer') {
         # Get PI Servers
         $regpathKST = 'HKLM:\SOFTWARE\PISystem\PI-SDK\1.0\ServerHandles'
-        $scriptBlock = {param([string]$RegPath) Get-ChildItem $RegPath | ForEach-Object {Get-ItemProperty $_.pspath} | where-object {$_.path} | Foreach-Object {$_.path}}
+        $scriptBlock = {param([string]$RegPath) Get-ChildItem $RegPath | ForEach-Object {Get-ItemProperty -LiteralPath $_.pspath} | where-object {$_.path} | Foreach-Object {$_.path}}
         if ($LocalComputer)
         { $KnownServers = & $scriptBlock -RegPath $regpathKST }
         Else


### PR DESCRIPTION
Fixes #424.  I also switched to -LiteralPath in other places I identified that we are getting paths that we do not want to support wildcards in.